### PR TITLE
Fix month name in Books template

### DIFF
--- a/src/components/literature/books/template.vue
+++ b/src/components/literature/books/template.vue
@@ -10,7 +10,7 @@ defineOptions({
 
 <template>
 
-    <ArticleTemplate title="Books" meta="Jan 4, 2025 by G. D. Ungureanu">
+    <ArticleTemplate title="Books" meta="Jun 4, 2025 by G. D. Ungureanu">
         <p>Work work work.</p>
 
         <SuggestionsTemplate :suggestions="suggestions" />

--- a/src/components/literature/books/template.vue
+++ b/src/components/literature/books/template.vue
@@ -10,7 +10,7 @@ defineOptions({
 
 <template>
 
-    <ArticleTemplate title="Books" meta="Jav 4, 2025 by G. D. Ungureanu">
+    <ArticleTemplate title="Books" meta="Jan 4, 2025 by G. D. Ungureanu">
         <p>Work work work.</p>
 
         <SuggestionsTemplate :suggestions="suggestions" />


### PR DESCRIPTION
## Summary
- Correct month abbreviation in Books page metadata

## Testing
- `npm test` *(fails: Invalid option '--ignore-path')*

------
https://chatgpt.com/codex/tasks/task_e_6893428867608323a4a398e214277d6d