### PR TITLE
fix: apply custom Bootstrap variables before import

### DIFF
--- a/src/scss/styles.scss
+++ b/src/scss/styles.scss
@@ -1,16 +1,15 @@
-@import "bootstrap/scss/bootstrap";
+@use "bootstrap/scss/bootstrap" with (
+  // Toggle global options
+  $enable-gradients: true,
+  $enable-shadows: true,
+  $offcanvas-box-shadow: 0 1rem 3rem rgba(0, 0, 0, .175),
 
-// Toggle global options
-$enable-gradients: true;
-$enable-shadows: true;
-
-$offcanvas-box-shadow: 0 1rem 3rem rgba(0, 0, 0, .175);
-
-// Customize defaults
-$body-color: #333;
-$body-bg: #fff;
-$border-radius: .4rem;
-$success: #7952b3;
+  // Customize defaults
+  $body-color: #333,
+  $body-bg: #fff,
+  $border-radius: .4rem,
+  $success: #7952b3
+);
 
 // Custom Badge Classes for Destinations
 .badge-mint-green {


### PR DESCRIPTION
## Summary
- ensure Bootstrap variables like gradients, colors, and radii are set via `@use` configuration so project settings override defaults

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689345d3d0d8832393101898d3664976