### PR TITLE
feat: add widescreen lint formatter

### DIFF
--- a/eslint-wide-formatter.js
+++ b/eslint-wide-formatter.js
@@ -1,0 +1,31 @@
+/* eslint-env node */
+/**
+ * Custom ESLint formatter that outputs results in a wide-screen friendly format.
+ * Lines and columns are padded so that messages align neatly when viewed on
+ * wider terminals.
+ *
+ * @param {import('eslint').ESLint.LintResult[]} results
+ * @returns {string}
+ */
+module.exports = (results) => {
+  const lines = [];
+
+  for (const result of results) {
+    if (result.messages.length === 0) continue;
+
+    lines.push(result.filePath);
+
+    for (const msg of result.messages) {
+      const line = String(msg.line).padStart(4);
+      const column = String(msg.column).padStart(4);
+      const type = msg.severity === 2 ? 'error' : 'warn';
+      lines.push(
+        `  ${line}:${column}  ${type.padEnd(5)}  ${msg.message}  ${msg.ruleId || ''}`.trimEnd()
+      );
+    }
+
+    lines.push('');
+  }
+
+  return lines.join('\n');
+};

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -17,6 +17,7 @@ module.exports = [
       'src/application.vue',
       'src/components/navigation/template.vue',
       'eslint.config.cjs',
+      'eslint-wide-formatter.js',
       'vite.config.js',
       'tests/**',
     ],

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start": "vite",
     "build": "vite build",
     "preview": "vite preview --port 4173",
-    "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs",
+    "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs -f ./eslint-wide-formatter.js",
     "fix": "npm run lint -- --fix",
     "test": "node --test --experimental-test-coverage && npm run lint",
     "predeploy": "npm run build",


### PR DESCRIPTION
## Summary
- use a custom ESLint formatter to better display results on wide screens
- run lint with the new formatter
- ignore the formatter file from linting

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68934a42300483239ecfdde853ba3e78