### PR TITLE
feat: persist suggestion statuses

### DIFF
--- a/src/components/entertainment/anime/template.vue
+++ b/src/components/entertainment/anime/template.vue
@@ -38,7 +38,7 @@ defineOptions({
         <p>I'm using <a href="https://myanimelist.net/" class="text-decoration-none">MyAnimeList.net</a> as my
             main source of reference.</p>
 
-        <SuggestionsTemplate :suggestions="suggestions" />
+        <SuggestionsTemplate :suggestions="suggestions" storage-key="entertainment-anime" />
         
         <p></p>
 

--- a/src/components/experiments/template.vue
+++ b/src/components/experiments/template.vue
@@ -18,7 +18,7 @@ defineOptions({
     </ArticleTemplate>
 
     <ArticleTemplate title="Working on Experiments" meta="June 28, 2025 by G. D. Ungureanu">
-        <SuggestionsTemplate :suggestions="suggestions" />
+        <SuggestionsTemplate :suggestions="suggestions" storage-key="experiments" />
     </ArticleTemplate>
 
     <ArticleTemplate title="Vișinată" meta="June 28, 2025 by G. D. Ungureanu">

--- a/src/components/home/template.vue
+++ b/src/components/home/template.vue
@@ -14,7 +14,7 @@ defineOptions({
     <ArticleTemplate title="Coding my passions" meta="May 26, 2025 by G. D. Ungureanu">
         <p>I'm coding because I like to.</p>
 
-        <SuggestionsTemplate :suggestions="suggestions" />
+        <SuggestionsTemplate :suggestions="suggestions" storage-key="home" />
     </ArticleTemplate>
 
     <ArticleTemplate title="Play the most Magnificent Game that you can!" meta="Jun 4, 2025 by G. D. Ungureanu">

--- a/src/components/ikigai/template.vue
+++ b/src/components/ikigai/template.vue
@@ -16,7 +16,7 @@ defineOptions({
     </ArticleTemplate>
 
     <ArticleTemplate title="Notes" meta="Jav 7, 2025 by G. D. Ungureanu">
-        <SuggestionsTemplate :suggestions="suggestions" />
+        <SuggestionsTemplate :suggestions="suggestions" storage-key="ikigai-notes" />
     </ArticleTemplate>
 
 

--- a/src/components/ippo/template.vue
+++ b/src/components/ippo/template.vue
@@ -13,7 +13,7 @@ defineOptions({
     <ArticleTemplate title="Steps that I would like to take" meta="May 26, 2025 by G. D. Ungureanu">
         <p>So many things To do/To learn.</p>
 
-        <SuggestionsTemplate :suggestions="suggestions" />
+        <SuggestionsTemplate :suggestions="suggestions" storage-key="ippo" />
     </ArticleTemplate>
 
 </template>

--- a/src/components/literature/books/template.vue
+++ b/src/components/literature/books/template.vue
@@ -13,7 +13,7 @@ defineOptions({
     <ArticleTemplate title="Books" meta="Jun 4, 2025 by G. D. Ungureanu">
         <p>Work work work.</p>
 
-        <SuggestionsTemplate :suggestions="suggestions" />
+        <SuggestionsTemplate :suggestions="suggestions" storage-key="literature-books" />
     </ArticleTemplate>
 
     <ArticleTemplate title="Atomic Habits" meta="Jun 7, 2025 by G. D. Ungureanu">

--- a/src/components/literature/poems/template.vue
+++ b/src/components/literature/poems/template.vue
@@ -13,7 +13,7 @@ defineOptions({
     <ArticleTemplate title="Poems" meta="May 26, 2025 by G. D. Ungureanu">
         <p>I'm working on compiling a list of Poems.</p>
 
-        <SuggestionsTemplate :suggestions="suggestions" />
+        <SuggestionsTemplate :suggestions="suggestions" storage-key="literature-poems" />
     </ArticleTemplate>
 
     <ArticleTemplate title="Memento Mori" meta="1872 by Mihai Eminescu">

--- a/src/templates/suggestions.vue
+++ b/src/templates/suggestions.vue
@@ -1,17 +1,42 @@
 <script setup>
-defineProps({
+import { ref, watch, onMounted } from 'vue';
+
+const props = defineProps({
     suggestions: {
         type: Array,
         required: true
+    },
+    storageKey: {
+        type: String,
+        required: true
     }
 });
+
+const localSuggestions = ref(props.suggestions.map(s => ({ ...s })));
+
+const getId = (index) => `${props.storageKey}-${index}`;
+
+onMounted(() => {
+    const stored = JSON.parse(localStorage.getItem(`suggestions_${props.storageKey}`));
+    if (stored && Array.isArray(stored)) {
+        localSuggestions.value = localSuggestions.value.map((s, idx) => ({
+            ...s,
+            status: stored[idx] ?? s.status
+        }));
+    }
+});
+
+watch(localSuggestions, (newVal) => {
+    const statuses = newVal.map(s => s.status);
+    localStorage.setItem(`suggestions_${props.storageKey}`, JSON.stringify(statuses));
+}, { deep: true });
 </script>
 
 <template>
     <p class="mb-2"><strong>Suggestions:</strong></p>
 
-    <div class="form-check" v-for="suggestion in suggestions">
-        <input type="checkbox" class="form-check-input" id="checkboxInput" v-model="suggestion.status">
-        <label class="form-check-label" for="checkboxInput">{{ suggestion.action }}</label>
+    <div class="form-check" v-for="(suggestion, index) in localSuggestions" :key="getId(index)">
+        <input type="checkbox" class="form-check-input" :id="getId(index)" v-model="suggestion.status">
+        <label class="form-check-label" :for="getId(index)">{{ suggestion.action }}</label>
     </div>
 </template>


### PR DESCRIPTION
## Summary
- assign unique ids and keys to suggestion checkboxes
- persist suggestion checkbox state in localStorage via `storageKey`
- wire up existing pages to provide unique storage keys for suggestion lists

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68934896a94083238b2add18657d3901