### PR TITLE
refactor: lazy load route components

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,69 +1,19 @@
 // Vue imports
 import { createApp } from 'vue'
-import { createWebHashHistory, createRouter } from 'vue-router'
 
 // Third-party library imports
-import { Popover } from 'bootstrap';
+import { Popover } from 'bootstrap'
 
 // Local component imports
 import App from './application.vue'
-import Home from './components/home/template.vue'
-import Ikigai from './components/ikigai/template.vue'
-import Ippo from './components/ippo/template.vue'
-import Experiments from './components/experiments/template.vue'
-import Random from './components/random/template.vue'
-
-// Literature Components
-import Literature from './components/literature/overview/template.vue'
-import Books from './components/literature/books/template.vue'
-import Poems from './components/literature/poems/template.vue'
-
-// Entertainment Components
-import Entertainment from './components/entertainment/overview/template.vue'
-import Anime from './components/entertainment/anime/template.vue'
-import Movies from './components/entertainment/movies/template.vue'
-
-// Nutrition Components
-import Nutrition from './components/nutrition/overview/template.vue'
-import Ingredients from './components/nutrition/ingredients/template.vue'
-
-// Adventure Components
-import Adventure from './components/adventure/overview/template.vue'
-import Destinations from './components/adventure/destinations/template.vue'
-
-// Practice Components
-import Practice from './components/practice/overview/template.vue'
-import Routines from './components/practice/routines/template.vue'
+import { createAppRouter } from './router.js'
 
 // Styles
 import './scss/styles.scss'
 import 'bootstrap-icons/font/bootstrap-icons.css'
 
-// Define the routes for the application
-const routes = [
-  { path: '/', component: Home },
-  { path: '/ikigai', component: Ikigai },
-  { path: '/ippo', component: Ippo },
-  { path: '/literature', component: Literature },
-  { path: '/books', component: Books },
-  { path: '/poems', component: Poems },
-  { path: '/entertainment', component: Entertainment },
-  { path: '/anime', component: Anime },
-  { path: '/movies', component: Movies },
-  { path: '/experiments', component: Experiments },
-  { path: '/random', component: Random },
-  { path: '/nutrition', component: Nutrition },
-  { path: '/nutrition/ingredients', component: Ingredients },
-  { path: '/adventure', component: Adventure },
-  { path: '/adventure/destinations', component: Destinations },
-  { path: '/practice', component: Practice },
-  { path: '/practice/routines', component: Routines },
-]
-
-const router = createRouter({
-  history: createWebHashHistory(),
-  routes,
-})
+// Create the router instance using centralized routes and auth guard
+const router = createAppRouter()
 
 createApp(App)
   .use(router)

--- a/src/router.js
+++ b/src/router.js
@@ -1,0 +1,20 @@
+import { createRouter, createWebHashHistory } from 'vue-router'
+import routes from './routes.js'
+import { useAuthentication } from './composables/useAuthentication.js'
+
+export function createAppRouter(history = createWebHashHistory(), routesConfig = routes) {
+  const router = createRouter({
+    history,
+    routes: routesConfig,
+  })
+
+  const auth = useAuthentication()
+
+  router.beforeEach(to => {
+    if (to.meta?.requiresAuth && !auth.isAuthenticated.value) {
+      return '/'
+    }
+  })
+
+  return router
+}

--- a/src/routes.js
+++ b/src/routes.js
@@ -1,0 +1,49 @@
+// Centralized route definitions with dynamic imports
+// Routes with `meta.requiresAuth: true` are protected and require authentication.
+const Home = () => import('./components/home/template.vue')
+const Ikigai = () => import('./components/ikigai/template.vue')
+const Ippo = () => import('./components/ippo/template.vue')
+const Experiments = () => import('./components/experiments/template.vue')
+const Random = () => import('./components/random/template.vue')
+
+// Literature Components
+const Literature = () => import('./components/literature/overview/template.vue')
+const Books = () => import('./components/literature/books/template.vue')
+const Poems = () => import('./components/literature/poems/template.vue')
+
+// Entertainment Components
+const Entertainment = () => import('./components/entertainment/overview/template.vue')
+const Anime = () => import('./components/entertainment/anime/template.vue')
+const Movies = () => import('./components/entertainment/movies/template.vue')
+
+// Nutrition Components
+const Nutrition = () => import('./components/nutrition/overview/template.vue')
+const Ingredients = () => import('./components/nutrition/ingredients/template.vue')
+
+// Adventure Components
+const Adventure = () => import('./components/adventure/overview/template.vue')
+const Destinations = () => import('./components/adventure/destinations/template.vue')
+
+// Practice Components
+const Practice = () => import('./components/practice/overview/template.vue')
+const Routines = () => import('./components/practice/routines/template.vue')
+
+export default [
+  { path: '/', component: Home },
+  { path: '/ikigai', component: Ikigai },
+  { path: '/ippo', component: Ippo },
+  { path: '/experiments', component: Experiments, meta: { requiresAuth: true } },
+  { path: '/random', component: Random },
+  { path: '/literature', component: Literature },
+  { path: '/books', component: Books },
+  { path: '/poems', component: Poems },
+  { path: '/entertainment', component: Entertainment },
+  { path: '/anime', component: Anime },
+  { path: '/movies', component: Movies },
+  { path: '/nutrition', component: Nutrition },
+  { path: '/nutrition/ingredients', component: Ingredients },
+  { path: '/adventure', component: Adventure },
+  { path: '/adventure/destinations', component: Destinations },
+  { path: '/practice', component: Practice, meta: { requiresAuth: true } },
+  { path: '/practice/routines', component: Routines },
+]

--- a/tests/routerGuard.test.js
+++ b/tests/routerGuard.test.js
@@ -1,0 +1,50 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { createMemoryHistory } from 'vue-router'
+import rawRoutes from '../src/routes.js'
+
+const PASSWORD = 'secret'
+
+async function setup(authenticated = false) {
+  const store = {}
+  global.sessionStorage = {
+    getItem: (key) => store[key] || null,
+    setItem: (key, value) => {
+      store[key] = value
+    },
+    removeItem: (key) => {
+      delete store[key]
+    },
+  }
+
+  process.env.VITE_APP_PASSWORD = PASSWORD
+
+  const { useAuthentication } = await import('../src/composables/useAuthentication.js')
+  const { createAppRouter } = await import('../src/router.js')
+
+  // Stub components to avoid loading .vue files
+  const routes = rawRoutes.map(route => ({ ...route, component: {} }))
+
+  const router = createAppRouter(createMemoryHistory(), routes)
+  const auth = useAuthentication()
+  auth.logout()
+  if (authenticated) auth.authenticate(PASSWORD)
+  await router.push('/')
+  return router
+}
+
+const protectedPaths = ['/experiments', '/practice']
+
+for (const path of protectedPaths) {
+  test(`redirects unauthenticated users from ${path}`, async () => {
+    const router = await setup(false)
+    await router.push(path)
+    assert.equal(router.currentRoute.value.fullPath, '/')
+  })
+
+  test(`allows authenticated users to access ${path}`, async () => {
+    const router = await setup(true)
+    await router.push(path)
+    assert.equal(router.currentRoute.value.fullPath, path)
+  })
+}


### PR DESCRIPTION
## Summary
- centralize route definitions with dynamic imports
- import routes in main entry and set up router
- enforce auth guard on protected routes and add tests
- document requiresAuth meta field for protected routes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895c9d9c82c83239d026bc1124764d8