### PR TITLE
docs: document components and expand module guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ npm run deploy
 
 This builds the project and deploys it to the `gh-pages` branch.
 
+## Documentation
+
+Additional reference material lives in the [`docs/`](docs) directory and in per-module `README.md` files inside `src/`.
+
 ## License
 
 MIT

--- a/docs/codemap.md
+++ b/docs/codemap.md
@@ -1,0 +1,12 @@
+# Code Map
+
+```mermaid
+graph TD;
+  main[main.js] --> router[router.js];
+  router --> routes[routes.js];
+  main --> components;
+  components --> composables;
+  composables --> config;
+```
+
+This Mermaid diagram sketches the primary runtime relationships. Components import composables for logic, which in turn depend on configuration modules such as Supabase.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,0 +1,5 @@
+# Glossary
+
+- **Ikigai** – Japanese concept meaning "reason for being"; section for purpose exploration.
+- **Ippo** – Japanese for "step"; contains incremental improvement tasks.
+- **Supabase** – backend-as-a-service used for data storage and authentication.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,13 @@
+# System Overview
+
+This project is a Vue 3 single-page application geared toward mindful living and personal growth. The frontend uses the Composition API and communicates with Supabase for persistence and authentication.
+
+## Modules
+
+- **Components** – feature-specific views rendered through Vue Router.
+- **Composables** – reusable logic such as authentication and action management.
+- **Config** – environment and third‑party service initialisation.
+- **Templates** – shared layout pieces for building new sections quickly.
+- **SCSS** – Bootstrap customisation and theme variables.
+
+See the README in each module for local development tips and entry points.

--- a/src/application.vue
+++ b/src/application.vue
@@ -7,6 +7,12 @@ import AppFooter from './components/footer/template.vue'
 import PasswordModal from './components/auth/PasswordModal.vue'
 import { useAuthentication } from './composables/useAuthentication.js'
 
+/**
+ * Root application shell. Renders navigation, header, footer and the active
+ * route content. It also guards restricted routes by showing a password modal
+ * when unauthenticated users attempt to access them.
+ */
+
 const router = useRouter()
 const route = useRoute()
 const { canAccessRoute, isRouteRestricted } = useAuthentication()

--- a/src/components/README.md
+++ b/src/components/README.md
@@ -1,0 +1,27 @@
+# Components
+
+Feature-oriented Vue components. Each subdirectory (e.g. `ikigai`, `nutrition`) exposes a `template.vue` file that is registered with Vue Router.
+
+### Key directories
+
+- `actions/` – interactive task list composed of `ActionList` and `ActionItem` components using the `useActions` composable.
+- `auth/` – password modal for gated routes.
+- `navigation/`, `header/`, `footer/` – layout chrome shared across pages.
+- Feature pages such as `adventure/`, `entertainment/`, `literature/`, `nutrition/`, `practice/`, `ikigai/`, `ippo/`, `random/` and `home/` each provide a router-mounted `template.vue` and optional JSON data files.
+
+## Dependencies
+
+- Vue 3 Composition API
+- Bootstrap 5
+
+## Local Development
+
+Components are compiled and hot‑reloaded via Vite. Run the application from the repository root:
+
+```sh
+npm start
+```
+
+## Entry Points
+
+Pages are rendered by `template.vue` files. Shared pieces such as headers and navigation live at the top level of this directory.

--- a/src/components/actions/ActionItem.vue
+++ b/src/components/actions/ActionItem.vue
@@ -2,6 +2,16 @@
 /* eslint-disable vue/no-mutating-props */
 import { defineProps, defineOptions } from 'vue'
 
+/**
+ * Display a single action row with edit, delete and priority controls.
+ *
+ * The component relies on the `useActions` state for all mutations. It accepts
+ * the current `action` record and the shared `state` object used across the
+ * action list.
+ *
+ * @prop {Action} action individual action record to render
+ * @prop {ActionsState} state reactive helpers returned by `useActions`
+ */
 defineOptions({ name: 'ActionItem' })
 
 /**

--- a/src/components/actions/ActionList.vue
+++ b/src/components/actions/ActionList.vue
@@ -4,6 +4,17 @@ import ActionItem from './ActionItem.vue'
 import { defineProps } from 'vue'
 
 /**
+ * Render and manage a hierarchical action list.
+ *
+ * Expects a `state` object from `useActions` containing the action data and
+ * CRUD helpers. The component itself does not emit events; instead it delegates
+ * all mutations to the provided state methods.
+ *
+ * @prop {ActionsState} state reactive collection of actions and helper
+ *   functions returned by `useActions`
+ */
+
+/**
  * Actions state returned by `useActions` composable.
  *
  * Properties include:

--- a/src/components/actions/README.md
+++ b/src/components/actions/README.md
@@ -1,0 +1,11 @@
+# Actions
+
+Task management components built around the `useActions` composable.
+
+## Components
+- `ActionList.vue` – top-level list UI, expects a `state` object from `useActions`.
+- `ActionItem.vue` – renders a single action with controls for edit, delete and priority.
+
+## Props & Events
+Both components receive an `ActionsState` object that contains reactive data and
+mutation methods. No events are emitted; mutations are delegated to the state.

--- a/src/components/adventure/README.md
+++ b/src/components/adventure/README.md
@@ -1,0 +1,7 @@
+# Adventure
+
+Travel and exploration related pages.
+
+## Submodules
+- `overview/` – introductory article for the adventure section.
+- `destinations/` – renders a list of travel destinations from `destinations.json`.

--- a/src/components/adventure/destinations/README.md
+++ b/src/components/adventure/destinations/README.md
@@ -1,0 +1,6 @@
+# Adventure Destinations
+
+Page listing travel destinations from `destinations.json`.
+
+## Component
+- `template.vue` – iterates over destinations list. No props.

--- a/src/components/adventure/overview/README.md
+++ b/src/components/adventure/overview/README.md
@@ -1,0 +1,6 @@
+# Adventure Overview
+
+Introductory article for the adventure section.
+
+## Component
+- `template.vue` – static page content. No props or events.

--- a/src/components/auth/PasswordModal.vue
+++ b/src/components/auth/PasswordModal.vue
@@ -2,6 +2,17 @@
 import { ref, nextTick, watch, computed } from 'vue'
 import { useAuthentication } from '../../composables/useAuthentication.js'
 
+/**
+ * Modal dialog prompting for a password before navigating to a restricted
+ * route.
+ *
+ * Props:
+ * - `show` toggles modal visibility
+ * - `targetRoute` optional path to redirect to after successful auth
+ *
+ * Emits `authenticated` with the target route on success and `hide` when the
+ * modal is dismissed.
+ */
 const props = defineProps({
   show: Boolean,
   targetRoute: String

--- a/src/components/auth/README.md
+++ b/src/components/auth/README.md
@@ -1,0 +1,11 @@
+# Auth
+
+Password-based authentication UI.
+
+## Components
+- `PasswordModal.vue` – asks for the site password before navigating to a restricted route.
+
+## Props & Events
+- `show` (`Boolean`) – controls visibility.
+- `targetRoute` (`String`) – optional redirect path after successful auth.
+- Emits `authenticated` with the route and `hide` when closed.

--- a/src/components/entertainment/README.md
+++ b/src/components/entertainment/README.md
@@ -1,0 +1,8 @@
+# Entertainment
+
+Pages for leisure recommendations.
+
+## Submodules
+- `overview/` – summary of entertainment content.
+- `anime/` – renders an anime checklist from `data.json`.
+- `movies/` – placeholder page for movie suggestions.

--- a/src/components/entertainment/anime/README.md
+++ b/src/components/entertainment/anime/README.md
@@ -1,0 +1,7 @@
+# Anime
+
+Checklist of anime titles.
+
+## Files
+- `template.vue` – renders suggestions from `data.json`.
+- `data.json` – list of anime titles and completion state.

--- a/src/components/entertainment/movies/README.md
+++ b/src/components/entertainment/movies/README.md
@@ -1,0 +1,6 @@
+# Movies
+
+Placeholder page for movie suggestions.
+
+## Component
+- `template.vue` – static content. No props or events.

--- a/src/components/entertainment/overview/README.md
+++ b/src/components/entertainment/overview/README.md
@@ -1,0 +1,6 @@
+# Entertainment Overview
+
+Landing page for entertainment content.
+
+## Component
+- `template.vue` – static description of the entertainment section.

--- a/src/components/experiments/README.md
+++ b/src/components/experiments/README.md
@@ -1,0 +1,7 @@
+# Experiments
+
+Personal experiments and notes.
+
+## Component
+- `template.vue` – displays experiment write-ups and images from the `assets/` folder.
+- `suggestions.json` – optional checklist for future experiments.

--- a/src/components/footer/README.md
+++ b/src/components/footer/README.md
@@ -1,0 +1,6 @@
+# Footer
+
+Simple page footer with attribution.
+
+## Component
+- `template.vue` – displays copyright and author link. No props or events.

--- a/src/components/header/README.md
+++ b/src/components/header/README.md
@@ -1,0 +1,6 @@
+# Header
+
+Static hero section displayed at the top of every page.
+
+## Component
+- `template.vue` – contains the project tagline and introductory text. No props or events.

--- a/src/components/home/README.md
+++ b/src/components/home/README.md
@@ -1,0 +1,6 @@
+# Home
+
+Landing page with introductory articles and an actions widget.
+
+## Component
+- `template.vue` – renders static articles and an `ActionsTemplate` bound to a predefined list ID.

--- a/src/components/ikigai/README.md
+++ b/src/components/ikigai/README.md
@@ -1,0 +1,6 @@
+# Ikigai
+
+Self-reflection notes and action list.
+
+## Component
+- `template.vue` – combines `ActionsTemplate` with a suggestions checklist loaded from `suggestions.json`.

--- a/src/components/ippo/README.md
+++ b/src/components/ippo/README.md
@@ -1,0 +1,6 @@
+# Ippo
+
+Work-in-progress page for personal projects.
+
+## Component
+- `template.vue` – placeholder article content. No props or events.

--- a/src/components/literature/README.md
+++ b/src/components/literature/README.md
@@ -1,0 +1,8 @@
+# Literature
+
+Reading notes and recommendations.
+
+## Submodules
+- `overview/` – summary of the literature section.
+- `books/` – book tracking page backed by `actions.sql`.
+- `poems/` – curated poem selections.

--- a/src/components/literature/books/README.md
+++ b/src/components/literature/books/README.md
@@ -1,0 +1,7 @@
+# Books
+
+Track reading progress using action lists.
+
+## Files
+- `template.vue` – displays book-related actions.
+- `actions.sql` – SQL schema for storing book actions in Supabase.

--- a/src/components/literature/overview/README.md
+++ b/src/components/literature/overview/README.md
@@ -1,0 +1,6 @@
+# Literature Overview
+
+Landing page for literature-related content.
+
+## Component
+- `template.vue` – static introduction. No props or events.

--- a/src/components/literature/poems/README.md
+++ b/src/components/literature/poems/README.md
@@ -1,0 +1,6 @@
+# Poems
+
+Curated poem selections.
+
+## Component
+- `template.vue` – lists poems. No props or events.

--- a/src/components/navigation/README.md
+++ b/src/components/navigation/README.md
@@ -1,0 +1,9 @@
+# Navigation
+
+Responsive site navigation bar.
+
+## Component
+- `template.vue` – builds menus from `useAuthentication` helpers and emits `showAuthentication` when login is requested.
+
+## Props & Events
+No props. Emits `showAuthentication` to trigger the password modal.

--- a/src/components/navigation/template.vue
+++ b/src/components/navigation/template.vue
@@ -3,6 +3,12 @@ import { ref, onMounted } from 'vue'
 import { Collapse } from 'bootstrap'
 import { useAuthentication } from '../../composables/useAuthentication.js'
 
+/**
+ * Top-level navigation bar showing public and restricted sections.
+ *
+ * Uses `useAuthentication` to build the menu dynamically and emits a
+ * `showAuthentication` event when the user requests to log in.
+ */
 const { isAuthenticated, dropdownSections, standaloneItems, logout } = useAuthentication()
 
 const emit = defineEmits(['showAuthentication'])

--- a/src/components/nutrition/README.md
+++ b/src/components/nutrition/README.md
@@ -1,0 +1,7 @@
+# Nutrition
+
+Food tracking and ingredient references.
+
+## Submodules
+- `overview/` – general nutrition information.
+- `ingredients/` – searchable ingredient list from `ingredients.json`.

--- a/src/components/nutrition/ingredients/README.md
+++ b/src/components/nutrition/ingredients/README.md
@@ -1,0 +1,7 @@
+# Ingredients
+
+Interactive ingredient explorer.
+
+## Files
+- `template.vue` – displays a searchable list of ingredients.
+- `ingredients.json` – ingredient data with nutritional info.

--- a/src/components/nutrition/overview/README.md
+++ b/src/components/nutrition/overview/README.md
@@ -1,0 +1,6 @@
+# Nutrition Overview
+
+Introduction to nutrition features.
+
+## Component
+- `template.vue` – static content outlining nutrition goals.

--- a/src/components/practice/README.md
+++ b/src/components/practice/README.md
@@ -1,0 +1,7 @@
+# Practice
+
+Habit and routine tracking.
+
+## Submodules
+- `overview/` – introduction to practice philosophy.
+- `routines/` – renders routines from `habits.json` and `activities.json` plus database schemas.

--- a/src/components/practice/overview/README.md
+++ b/src/components/practice/overview/README.md
@@ -1,0 +1,6 @@
+# Practice Overview
+
+Overview of habit practice section.
+
+## Component
+- `template.vue` – static description. No props or events.

--- a/src/components/practice/routines/README.md
+++ b/src/components/practice/routines/README.md
@@ -1,0 +1,8 @@
+# Routines
+
+Routines and habit trackers.
+
+## Files
+- `template.vue` – renders routines and activities.
+- `habits.json`, `activities.json` – data sources for routines.
+- `schemas/` – database schema references.

--- a/src/components/random/README.md
+++ b/src/components/random/README.md
@@ -1,0 +1,6 @@
+# Random
+
+Miscellaneous notes and pages.
+
+## Component
+- `template.vue` – placeholder page with arbitrary content. No props or events.

--- a/src/composables/README.md
+++ b/src/composables/README.md
@@ -1,0 +1,35 @@
+# Composables
+
+Reusable logic for Vue components.
+
+## Provided Utilities
+
+### `useAuthentication`
+
+Manages in-memory and `sessionStorage`-backed auth state. Returns reactive
+helpers for logging in/out and for building navigation menus.
+
+- **Inputs:** `authenticate(password)` expects the plain-text password.
+- **Outputs:** `isAuthenticated` flag and navigation/route guard utilities.
+
+### `useActions`
+
+CRUD layer for action lists stored in Supabase with local caching and
+optimistic updates.
+
+- **Inputs:** `listIdRef` (`Ref<string>`) identifying the list to manage.
+- **Outputs:** reactive `actions`, computed `rootActions`, and mutation
+  functions such as `addAction`, `updateActionStatus`, `updateActionPriority`
+  and `deleteAction`.
+
+## Local Development
+
+These modules are plain JavaScript and automatically bundled. No extra build steps are needed beyond running the dev server:
+
+```sh
+npm start
+```
+
+## Entry Points
+
+Each composable exports a function as its default API. Import them into components as needed.

--- a/src/composables/useActions.js
+++ b/src/composables/useActions.js
@@ -1,6 +1,31 @@
 import { ref, watch, computed, nextTick } from 'vue'
 import { supabase } from '../config/supabase.js'
 
+/**
+ * Provides reactive state and helper methods for working with an actions list
+ * stored in Supabase.
+ *
+ * Features:
+ * - local sessionStorage caching with expiry
+ * - hierarchical parent/child actions
+ * - optimistic updates and rollback on failure
+ * - helper getters for root actions and sub-actions
+ *
+ * @param {import('vue').Ref<string>} listIdRef reactive identifier for the
+ *   current action list
+ * @returns {{
+ *   actions: import('vue').Ref<Array>,
+ *   rootActions: import('vue').ComputedRef<Array>,
+ *   fetchActions: () => Promise<void>,
+ *   addAction: (parentId?: string) => Promise<void>,
+ *   updateActionStatus: (action: any) => Promise<void>,
+ *   updateActionDescription: (action: any, text: string) => Promise<void>,
+ *   updateActionPriority: (action: any, priority: number) => Promise<void>,
+ *   deleteAction: (id: string) => Promise<void>,
+ *   clearCachedActions: () => void,
+ *   /* plus additional reactive properties omitted for brevity */
+ * }} state, getters and mutation functions for the list
+ */
 export function useActions(listIdRef) {
   // Cache utilities using sessionStorage to persist across module reloads
   const getCachedActions = () => {

--- a/src/composables/useAuthentication.js
+++ b/src/composables/useAuthentication.js
@@ -49,6 +49,29 @@ const restrictedRoutes = [
   '/random'
 ]
 
+/**
+ * Manage client-side authentication state and navigation visibility.
+ *
+ * Returned helpers include:
+ * - `isAuthenticated` reactive boolean flag
+ * - `authenticate(password)` to set the flag when the supplied password
+ *   matches the configured value
+ * - `logout()` to clear the session
+ * - route helpers: `isRouteRestricted`, `isRoutePublic`, `canAccessRoute`
+ * - navigation builders: `navigationItems`, `dropdownSections`, `standaloneItems`
+ *
+ * @returns {{
+ *  isAuthenticated: import('vue').ComputedRef<boolean>,
+ *  authenticate: (password: string) => boolean,
+ *  logout: () => void,
+ *  isRouteRestricted: (path: string) => boolean,
+ *  isRoutePublic: (path: string) => boolean,
+ *  canAccessRoute: (path: string) => boolean,
+ *  navigationItems: import('vue').ComputedRef<Array>,
+ *  dropdownSections: import('vue').ComputedRef<Record<string, any>>,
+ *  standaloneItems: import('vue').ComputedRef<Array>
+ * }} reactive auth helpers and route guards
+ */
 export function useAuthentication() {
   
   const authenticate = (password) => {

--- a/src/config/README.md
+++ b/src/config/README.md
@@ -1,0 +1,26 @@
+# Config
+
+Centralised configuration and third‑party clients.
+
+## Supabase
+
+`supabase.js` initialises the Supabase client using environment variables:
+
+- `VITE_SUPABASE_URL` – project URL
+- `VITE_SUPABASE_ANON_KEY` – public anon key
+
+The exported `supabase` instance is used by composables such as `useActions`
+to perform database reads/writes.
+
+## Local Development
+
+Create a `.env` file with the variables above and start the dev server:
+
+```sh
+npm start
+```
+
+## Entry Points
+
+Import from this directory when a component or composable needs to talk to
+external services or shared configuration.

--- a/src/config/supabase.js
+++ b/src/config/supabase.js
@@ -1,6 +1,16 @@
 /* global process */
 import { createClient } from '@supabase/supabase-js';
 
+/**
+ * Initialise and export a configured Supabase client.
+ *
+ * Reads credentials from `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY`
+ * environment variables (supporting both Vite's `import.meta.env` and
+ * `process.env`). The function throws during module evaluation if either value
+ * is missing so that misconfiguration is surfaced immediately.
+ *
+ * @returns {import('@supabase/supabase-js').SupabaseClient} ready-to-use client
+ */
 // Environment variables with fallbacks for development and testing
 const supabaseUrl = import.meta.env?.VITE_SUPABASE_URL || process.env.VITE_SUPABASE_URL;
 const supabaseKey = import.meta.env?.VITE_SUPABASE_ANON_KEY || process.env.VITE_SUPABASE_ANON_KEY;

--- a/src/main.js
+++ b/src/main.js
@@ -15,6 +15,10 @@ import 'bootstrap-icons/font/bootstrap-icons.css'
 // Create the router instance using centralized routes and auth guard
 const router = createAppRouter()
 
+/**
+ * Application bootstrap. Mounts the root component with the configured
+ * router and wires up Bootstrap popovers for opt-in elements.
+ */
 createApp(App)
   .use(router)
   .mount('#app')

--- a/src/router.js
+++ b/src/router.js
@@ -2,6 +2,16 @@ import { createRouter, createWebHashHistory } from 'vue-router'
 import routes from './routes.js'
 import { useAuthentication } from './composables/useAuthentication.js'
 
+/**
+ * Create a Vue Router instance with a simple authentication guard.
+ *
+ * Any route whose `meta.requiresAuth` flag is `true` will redirect to `/` when
+ * the user is not authenticated according to `useAuthentication`.
+ *
+ * @param {import('vue-router').RouterHistory} [history] custom history implementation
+ * @param {Array<import('vue-router').RouteRecordRaw>} [routesConfig] route definitions
+ * @returns {import('vue-router').Router} configured router
+ */
 export function createAppRouter(history = createWebHashHistory(), routesConfig = routes) {
   const router = createRouter({
     history,

--- a/src/routes.js
+++ b/src/routes.js
@@ -1,5 +1,11 @@
-// Centralized route definitions with dynamic imports
+// Centralized route definitions with dynamic imports.
 // Routes with `meta.requiresAuth: true` are protected and require authentication.
+
+/**
+ * Export an array of `RouteRecordRaw` objects consumed by Vue Router.
+ * Dynamic imports keep bundle size small and the optional `meta.requiresAuth`
+ * flag marks routes that should be hidden behind the password modal.
+ */
 const Home = () => import('./components/home/template.vue')
 const Ikigai = () => import('./components/ikigai/template.vue')
 const Ippo = () => import('./components/ippo/template.vue')

--- a/src/scss/README.md
+++ b/src/scss/README.md
@@ -1,0 +1,18 @@
+# SCSS
+
+Custom Bootstrap variables and utility classes. Overrides live in
+`_variables.scss`; additional helpers can be added under this directory and
+imported from `main.scss`.
+
+## Local Development
+
+Styles are compiled by Vite automatically. To watch for changes:
+
+```sh
+npm start
+```
+
+## Entry Points
+
+`main.scss` is imported in `main.js` and serves as the root of the style
+dependency tree.

--- a/src/templates/README.md
+++ b/src/templates/README.md
@@ -1,0 +1,20 @@
+# Templates
+
+Shared Vue components that act as structural layouts for feature sections. They
+provide consistent markup for lists, articles and suggestions so feature modules
+only worry about content.
+
+## Local Development
+
+Templates are imported by feature modules and require no special setup beyond
+the standard dev server:
+
+```sh
+npm start
+```
+
+## Entry Points
+
+- `article.vue` – basic article layout with title and metadata slots
+- `actions.vue` – wrapper around the `useActions` composable rendering an action list by ID
+- `suggestions.vue` – renders a checklist from JSON data

--- a/src/templates/actions.vue
+++ b/src/templates/actions.vue
@@ -3,6 +3,12 @@ import { toRef } from 'vue'
 import ActionList from '../components/actions/ActionList.vue'
 import { useActions } from '../composables/useActions.js'
 
+/**
+ * Convenience wrapper that wires a `listId` prop to the `useActions`
+ * composable and renders the resulting `ActionList`.
+ *
+ * @prop {string} listId identifier of the actions list in Supabase
+ */
 const props = defineProps({
   listId: {
     type: String,

--- a/src/templates/article.vue
+++ b/src/templates/article.vue
@@ -1,8 +1,14 @@
 <script setup>
-    defineProps({
-        title: String,
-        meta: String
-    });
+/**
+ * Basic article layout with a header and body slot.
+ *
+ * @prop {string} title heading text displayed above the content slot
+ * @prop {string} meta small subtitle or metadata string
+ */
+defineProps({
+    title: String,
+    meta: String
+});
 </script>
 
 <template>

--- a/src/templates/suggestions.vue
+++ b/src/templates/suggestions.vue
@@ -1,4 +1,10 @@
 <script setup>
+/**
+ * Render a checklist of suggestions.
+ *
+ * @prop {Array<{action:string,status:boolean}>} suggestions array of items to
+ *   display with checkbox state
+ */
 defineProps({
     suggestions: {
         type: Array,


### PR DESCRIPTION
## Summary
- add README guides for each component and feature folder
- clarify composables, templates and config with detailed docstrings
- explain Supabase setup and router guards

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895e5b1bbe48323b83dbb49cce2acd6