### PR TITLE
feat(auth): guard against missing password env var

### DIFF
--- a/src/composables/useAuthentication.js
+++ b/src/composables/useAuthentication.js
@@ -3,6 +3,10 @@ import { ref, computed, watchEffect } from 'vue'
 // Password from environment variable (fallback to process.env for tests)
 const CORRECT_PASSWORD = import.meta.env?.VITE_APP_PASSWORD || globalThis.process?.env?.VITE_APP_PASSWORD
 
+if (!CORRECT_PASSWORD) {
+  throw new Error('VITE_APP_PASSWORD environment variable is not configured')
+}
+
 // Reactive authentication state
 const isAuthenticated = ref(false)
 

--- a/tests/useAuthentication.test.js
+++ b/tests/useAuthentication.test.js
@@ -1,5 +1,6 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
 
 const PASSWORD = 'secret'
 
@@ -39,4 +40,22 @@ test('route access control', async () => {
   assert.equal(auth.canAccessRoute('/practice'), false)
   auth.authenticate(PASSWORD)
   assert.equal(auth.canAccessRoute('/practice'), true)
+})
+
+test('fails fast when password variable is absent', () => {
+  const env = { ...process.env }
+  delete env.VITE_APP_PASSWORD
+
+  const result = spawnSync(
+    process.execPath,
+    ['--input-type=module', '--eval', "import('./src/composables/useAuthentication.js')"],
+    {
+      cwd: process.cwd(),
+      env,
+      encoding: 'utf-8'
+    }
+  )
+
+  assert.notEqual(result.status, 0)
+  assert.match(result.stderr, /VITE_APP_PASSWORD/)
 })


### PR DESCRIPTION
## Summary
- Throw a clear error when `VITE_APP_PASSWORD` is missing
- Test authentication composable fails fast without the password

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689602771b7483239294e85d29633263