### PR TITLE
fix: correct ISO week-year formatting

### DIFF
--- a/src/pages/practice/routines/Routines.vue
+++ b/src/pages/practice/routines/Routines.vue
@@ -315,10 +315,15 @@ Contrast verification (AA):
         return date.toISOString().split('T')[0] // YYYY-MM-DD
 
       case 'week': {
-        // Calculate ISO week number
-        const yearStart = new Date(date.getFullYear(), 0, 1)
-        const weekNum = Math.ceil(((date - yearStart) / 86400000 + yearStart.getDay() + 1) / 7)
-        return `${date.getFullYear()}-W${weekNum.toString().padStart(2, '0')}`
+        // Calculate ISO week number and associated week-year
+        const temp = new Date(date)
+        temp.setHours(0, 0, 0, 0)
+        const day = temp.getDay() || 7 // ISO: Mon=1, Sun=7
+        temp.setDate(temp.getDate() + 4 - day) // Move to Thursday to determine week-year
+        const weekYear = temp.getFullYear()
+        const yearStart = new Date(weekYear, 0, 1)
+        const weekNum = Math.ceil(((temp - yearStart) / 86400000 + 1) / 7)
+        return `${weekYear}-W${weekNum.toString().padStart(2, '0')}`
       }
 
       case 'month':
@@ -327,6 +332,18 @@ Contrast verification (AA):
       case 'year':
         return date.getFullYear().toString()
     }
+  }
+
+  if (import.meta.env.DEV) {
+    // Console checks for ISO week-year edge cases
+    console.assert(
+      formatIntervalId('week', new Date('2015-12-31')) === '2015-W53',
+      '2015-12-31 should be in 2015-W53'
+    )
+    console.assert(
+      formatIntervalId('week', new Date('2016-01-01')) === '2015-W53',
+      '2016-01-01 should be in 2015-W53'
+    )
   }
 
   function humanLabel(scope, start, end) {

--- a/tests/actionUtils.test.js
+++ b/tests/actionUtils.test.js
@@ -1,6 +1,10 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { getPriorityText, getPriorityClass, PRIORITY_LEVELS } from '../src/templates/actions/utils.js'
+import {
+  getPriorityText,
+  getPriorityClass,
+  PRIORITY_LEVELS,
+} from '../src/components/shared/templates/actions/utils.js'
 
 test('getPriorityText returns correct labels', () => {
   assert.equal(getPriorityText(PRIORITY_LEVELS.LOW), 'Low')


### PR DESCRIPTION
## Summary
- compute ISO week numbers with accurate week-year to handle year-end dates
- add console assertions validating week-year edge cases
- fix broken import path in action utils tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68963c7d401c83238ad6a458b618b974