### PR TITLE
Add page render and route resolution tests

### DIFF
--- a/tests/pageTestUtils.js
+++ b/tests/pageTestUtils.js
@@ -1,0 +1,66 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { parse, compileScript, compileTemplate } from '@vue/compiler-sfc'
+import * as Vue from 'vue'
+import { createSSRApp } from 'vue'
+import { renderToString } from 'vue/server-renderer'
+import rawRoutes from '../src/routes.js'
+import { createMemoryHistory } from 'vue-router'
+
+/**
+ * Compile and render a Vue Single File Component to string.
+ * Imports are replaced with empty stubs to avoid loading child components.
+ * @param {string} file - Path to the .vue file relative to project root.
+ * @returns {Promise<string>} rendered HTML string
+ */
+export async function renderComponent(file) {
+  const filePath = path.resolve(file)
+  const src = readFileSync(filePath, 'utf-8')
+  const { descriptor } = parse(src, { filename: filePath })
+  let script = compileScript(descriptor, { id: filePath }).content
+  // Replace any import statements with empty stubs
+  script = script.replace(/import\s+([\s\S]+?)\s+from\s+['"][^'"]+['"];?\n?/g, 'const $1 = {}\n')
+  script = script.replace('export default', 'const __default__ =')
+  const template = compileTemplate({
+    source: descriptor.template?.content || '',
+    filename: filePath,
+    id: filePath,
+    compilerOptions: { mode: 'function' },
+  })
+  const code = `${script}\n${template.code}\nreturn { ...__default__, render }`
+  const component = new Function('Vue', code)(Vue)
+  const app = createSSRApp(component)
+  return renderToString(app)
+}
+
+/**
+ * Resolve a route using a memory history router and return the final path.
+ * Sets up a minimal authentication environment required by the router.
+ * @param {string} pathName
+ * @param {boolean} authenticated whether to authenticate before navigating
+ * @returns {Promise<string>} resolved path
+ */
+export async function resolveRoute(pathName, authenticated = false) {
+  const store = {}
+  global.sessionStorage = {
+    getItem: (k) => store[k] || null,
+    setItem: (k, v) => {
+      store[k] = v
+    },
+    removeItem: (k) => {
+      delete store[k]
+    },
+  }
+  process.env.VITE_APP_PASSWORD = 'secret'
+
+  const routes = rawRoutes.map((r) => ({ ...r, component: {} }))
+  const { createAppRouter } = await import('../src/router.js')
+  const router = createAppRouter(createMemoryHistory(), routes)
+  const { useAuthentication } = await import('../src/composables/useAuthentication.js')
+  const auth = useAuthentication()
+  auth.logout()
+  if (authenticated) auth.authenticate('secret')
+  await router.push(pathName)
+  await router.isReady()
+  return router.currentRoute.value.fullPath
+}

--- a/tests/pages/adventure/adventure.test.js
+++ b/tests/pages/adventure/adventure.test.js
@@ -1,0 +1,16 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { renderComponent, resolveRoute } from '../../pageTestUtils.js'
+
+const file = 'src/pages/adventure/Adventure.vue'
+const path = '/adventure'
+
+test('Adventure page renders without errors', async () => {
+  const html = await renderComponent(file)
+  assert.ok(html.length > 0)
+})
+
+test('Adventure route resolves', async () => {
+  const resolved = await resolveRoute(path)
+  assert.equal(resolved, path)
+})

--- a/tests/pages/adventure/destinations/destinations.test.js
+++ b/tests/pages/adventure/destinations/destinations.test.js
@@ -1,0 +1,16 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { renderComponent, resolveRoute } from '../../../pageTestUtils.js'
+
+const file = 'src/pages/adventure/destinations/Destinations.vue'
+const path = '/adventure/destinations'
+
+test('Destinations page renders without errors', async () => {
+  const html = await renderComponent(file)
+  assert.ok(html.length > 0)
+})
+
+test('Destinations route resolves', async () => {
+  const resolved = await resolveRoute(path)
+  assert.equal(resolved, path)
+})

--- a/tests/pages/entertainment.test.js
+++ b/tests/pages/entertainment.test.js
@@ -1,0 +1,23 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { renderComponent, resolveRoute } from '../pageTestUtils.js'
+import path from 'node:path'
+
+const pages = [
+  { file: 'src/pages/entertainment/Entertainment.vue', route: '/entertainment' },
+  { file: 'src/pages/entertainment/Anime.vue', route: '/anime' },
+  { file: 'src/pages/entertainment/Movies.vue', route: '/movies' },
+]
+
+for (const { file, route } of pages) {
+  const name = path.basename(file)
+  test(`${name} renders without errors`, async () => {
+    const html = await renderComponent(file)
+    assert.ok(html.length > 0)
+  })
+
+  test(`route ${route} resolves`, async () => {
+    const resolved = await resolveRoute(route)
+    assert.equal(resolved, route)
+  })
+}

--- a/tests/pages/experiments.test.js
+++ b/tests/pages/experiments.test.js
@@ -1,0 +1,16 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { renderComponent, resolveRoute } from '../pageTestUtils.js'
+
+const file = 'src/pages/experiments/Experiments.vue'
+const path = '/experiments'
+
+test('Experiments page renders without errors', async () => {
+  const html = await renderComponent(file)
+  assert.ok(html.length > 0)
+})
+
+test('Experiments route resolves', async () => {
+  const resolved = await resolveRoute(path, true)
+  assert.equal(resolved, path)
+})

--- a/tests/pages/home.test.js
+++ b/tests/pages/home.test.js
@@ -1,0 +1,16 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { renderComponent, resolveRoute } from '../pageTestUtils.js'
+
+const file = 'src/pages/home/Home.vue'
+const path = '/'
+
+test('Home page renders without errors', async () => {
+  const html = await renderComponent(file)
+  assert.ok(html.length > 0)
+})
+
+test('Home route resolves', async () => {
+  const resolved = await resolveRoute(path)
+  assert.equal(resolved, path)
+})

--- a/tests/pages/ikigai.test.js
+++ b/tests/pages/ikigai.test.js
@@ -1,0 +1,16 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { renderComponent, resolveRoute } from '../pageTestUtils.js'
+
+const file = 'src/pages/ikigai/Ikigai.vue'
+const path = '/ikigai'
+
+test('Ikigai page renders without errors', async () => {
+  const html = await renderComponent(file)
+  assert.ok(html.length > 0)
+})
+
+test('Ikigai route resolves', async () => {
+  const resolved = await resolveRoute(path, true)
+  assert.equal(resolved, path)
+})

--- a/tests/pages/ippo.test.js
+++ b/tests/pages/ippo.test.js
@@ -1,0 +1,16 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { renderComponent, resolveRoute } from '../pageTestUtils.js'
+
+const file = 'src/pages/ippo/Ippo.vue'
+const path = '/ippo'
+
+test('Ippo page renders without errors', async () => {
+  const html = await renderComponent(file)
+  assert.ok(html.length > 0)
+})
+
+test('Ippo route resolves', async () => {
+  const resolved = await resolveRoute(path, true)
+  assert.equal(resolved, path)
+})

--- a/tests/pages/literature/books/books.test.js
+++ b/tests/pages/literature/books/books.test.js
@@ -1,0 +1,16 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { renderComponent, resolveRoute } from '../../../pageTestUtils.js'
+
+const file = 'src/pages/literature/books/Books.vue'
+const path = '/books'
+
+test('Books page renders without errors', async () => {
+  const html = await renderComponent(file)
+  assert.ok(html.length > 0)
+})
+
+test('Books route resolves', async () => {
+  const resolved = await resolveRoute(path)
+  assert.equal(resolved, path)
+})

--- a/tests/pages/literature/literature.test.js
+++ b/tests/pages/literature/literature.test.js
@@ -1,0 +1,16 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { renderComponent, resolveRoute } from '../../pageTestUtils.js'
+
+const file = 'src/pages/literature/Literature.vue'
+const path = '/literature'
+
+test('Literature page renders without errors', async () => {
+  const html = await renderComponent(file)
+  assert.ok(html.length > 0)
+})
+
+test('Literature route resolves', async () => {
+  const resolved = await resolveRoute(path)
+  assert.equal(resolved, path)
+})

--- a/tests/pages/literature/poems/poems.test.js
+++ b/tests/pages/literature/poems/poems.test.js
@@ -1,0 +1,16 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { renderComponent, resolveRoute } from '../../../pageTestUtils.js'
+
+const file = 'src/pages/literature/poems/Poems.vue'
+const path = '/poems'
+
+test('Poems page renders without errors', async () => {
+  const html = await renderComponent(file)
+  assert.ok(html.length > 0)
+})
+
+test('Poems route resolves', async () => {
+  const resolved = await resolveRoute(path)
+  assert.equal(resolved, path)
+})

--- a/tests/pages/nutrition/ingredients/ingredients.test.js
+++ b/tests/pages/nutrition/ingredients/ingredients.test.js
@@ -1,0 +1,16 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { renderComponent, resolveRoute } from '../../../pageTestUtils.js'
+
+const file = 'src/pages/nutrition/ingredients/Ingredients.vue'
+const path = '/nutrition/ingredients'
+
+test('Ingredients page renders without errors', async () => {
+  const html = await renderComponent(file)
+  assert.ok(html.length > 0)
+})
+
+test('Ingredients route resolves', async () => {
+  const resolved = await resolveRoute(path)
+  assert.equal(resolved, path)
+})

--- a/tests/pages/nutrition/nutrition.test.js
+++ b/tests/pages/nutrition/nutrition.test.js
@@ -1,0 +1,16 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { renderComponent, resolveRoute } from '../../pageTestUtils.js'
+
+const file = 'src/pages/nutrition/Nutrition.vue'
+const path = '/nutrition'
+
+test('Nutrition page renders without errors', async () => {
+  const html = await renderComponent(file)
+  assert.ok(html.length > 0)
+})
+
+test('Nutrition route resolves', async () => {
+  const resolved = await resolveRoute(path)
+  assert.equal(resolved, path)
+})

--- a/tests/pages/practice/practice.test.js
+++ b/tests/pages/practice/practice.test.js
@@ -1,0 +1,16 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { renderComponent, resolveRoute } from '../../pageTestUtils.js'
+
+const file = 'src/pages/practice/Practice.vue'
+const path = '/practice'
+
+test('Practice page renders without errors', async () => {
+  const html = await renderComponent(file)
+  assert.ok(html.length > 0)
+})
+
+test('Practice route resolves', async () => {
+  const resolved = await resolveRoute(path, true)
+  assert.equal(resolved, path)
+})

--- a/tests/pages/practice/routines/routines.test.js
+++ b/tests/pages/practice/routines/routines.test.js
@@ -1,0 +1,16 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { renderComponent, resolveRoute } from '../../../pageTestUtils.js'
+
+const file = 'src/pages/practice/routines/Routines.vue'
+const path = '/practice/routines'
+
+test('Routines page renders without errors', async () => {
+  const html = await renderComponent(file)
+  assert.ok(html.length > 0)
+})
+
+test('Routines route resolves', async () => {
+  const resolved = await resolveRoute(path, true)
+  assert.equal(resolved, path)
+})

--- a/tests/pages/random.test.js
+++ b/tests/pages/random.test.js
@@ -1,0 +1,16 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { renderComponent, resolveRoute } from '../pageTestUtils.js'
+
+const file = 'src/pages/random/Random.vue'
+const path = '/random'
+
+test('Random page renders without errors', async () => {
+  const html = await renderComponent(file)
+  assert.ok(html.length > 0)
+})
+
+test('Random route resolves', async () => {
+  const resolved = await resolveRoute(path, true)
+  assert.equal(resolved, path)
+})


### PR DESCRIPTION
## Summary
- add a lightweight renderer to compile and mount Vue SFC pages in tests
- verify each page component renders and its route resolves

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68963b2cd0348323a553eced3c1f5d07