### PR TITLE
chore: add path alias

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,11 +1,11 @@
 <script setup>
   import { ref, onMounted, onBeforeUnmount } from 'vue'
   import { useRouter } from 'vue-router'
-  import AppNavigation from './components/layout/navigation/AppNavigation.vue'
-  import AppHeader from './components/layout/header/AppHeader.vue'
-  import AppFooter from './components/layout/footer/AppFooter.vue'
-  import PasswordModal from './components/shared/auth/PasswordModal.vue'
-  import { authEvents, AUTH_REQUIRED_EVENT } from './authEvents.js'
+  import AppNavigation from '@/components/layout/navigation/AppNavigation.vue'
+  import AppHeader from '@/components/layout/header/AppHeader.vue'
+  import AppFooter from '@/components/layout/footer/AppFooter.vue'
+  import PasswordModal from '@/components/shared/auth/PasswordModal.vue'
+  import { authEvents, AUTH_REQUIRED_EVENT } from '@/authEvents.js'
 
   /**
    * Root application shell. Renders navigation, header, footer and the active

--- a/src/components/layout/navigation/AppNavigation.vue
+++ b/src/components/layout/navigation/AppNavigation.vue
@@ -1,7 +1,7 @@
 <script setup>
   import { ref, onMounted } from 'vue'
   import { Collapse } from 'bootstrap'
-  import { useAuthentication } from '../../../composables/useAuthentication.js'
+  import { useAuthentication } from '@/composables/useAuthentication.js'
 
   /**
    * Top-level navigation bar showing public and restricted sections.

--- a/src/components/shared/auth/PasswordModal.vue
+++ b/src/components/shared/auth/PasswordModal.vue
@@ -1,6 +1,6 @@
 <script setup>
   import { ref, nextTick, watch, computed } from 'vue'
-  import { useAuthentication } from '../../../composables/useAuthentication.js'
+  import { useAuthentication } from '@/composables/useAuthentication.js'
 
   /**
    * Modal dialog prompting for a password before navigating to a restricted

--- a/src/components/shared/templates/Actions.vue
+++ b/src/components/shared/templates/Actions.vue
@@ -1,6 +1,6 @@
 <script setup>
   import { ref, watch, computed, nextTick } from 'vue'
-  import { supabase } from '../../../config/supabase.js'
+  import { supabase } from '@/config/supabase.js'
   import ActionItem from './actions/ActionItem.vue'
   import DeleteModal from './actions/DeleteModal.vue'
   import { PRIORITY_LEVELS } from './actions/utils.js'

--- a/src/composables/useAuthentication.js
+++ b/src/composables/useAuthentication.js
@@ -1,5 +1,5 @@
 import { ref, computed, watchEffect } from 'vue'
-import routes from '../routes.js'
+import routes from '@/routes.js'
 
 // Password from environment variable (fallback to process.env for tests)
 const CORRECT_PASSWORD = import.meta.env?.VITE_APP_PASSWORD || globalThis.process?.env?.VITE_APP_PASSWORD

--- a/src/main.js
+++ b/src/main.js
@@ -5,11 +5,11 @@ import { createApp } from 'vue'
 import { Popover } from 'bootstrap'
 
 // Local component imports
-import App from './App.vue'
-import { createAppRouter } from './router.js'
+import App from '@/App.vue'
+import { createAppRouter } from '@/router.js'
 
 // Styles
-import './scss/styles.scss'
+import '@/scss/styles.scss'
 import 'bootstrap-icons/font/bootstrap-icons.css'
 
 // Create the router instance using centralized routes and auth guard

--- a/src/pages/adventure/Adventure.vue
+++ b/src/pages/adventure/Adventure.vue
@@ -1,6 +1,6 @@
 <script setup>
-  import ArticleTemplate from '../../components/shared/templates/Article.vue'
-  import ActionsTemplate from '../../components/shared/templates/Actions.vue'
+  import ArticleTemplate from '@/components/shared/templates/Article.vue'
+  import ActionsTemplate from '@/components/shared/templates/Actions.vue'
 
   defineOptions({
     name: 'BucketListTemplate',

--- a/src/pages/adventure/destinations/Destinations.vue
+++ b/src/pages/adventure/destinations/Destinations.vue
@@ -2,8 +2,8 @@
   import { onMounted, ref, nextTick, computed } from 'vue'
   import L from 'leaflet'
   import 'leaflet/dist/leaflet.css'
-  import ArticleTemplate from '../../../components/shared/templates/Article.vue'
-  import ActionsTemplate from '../../../components/shared/templates/Actions.vue'
+  import ArticleTemplate from '@/components/shared/templates/Article.vue'
+  import ActionsTemplate from '@/components/shared/templates/Actions.vue'
   import destinationsData from './destinations.json'
 
   defineOptions({

--- a/src/pages/entertainment/Anime.vue
+++ b/src/pages/entertainment/Anime.vue
@@ -19,8 +19,8 @@
 -->
 
 <script setup>
-  import ArticleTemplate from '../../components/shared/templates/Article.vue'
-  import ActionsTemplate from '../../components/shared/templates/Actions.vue'
+  import ArticleTemplate from '@/components/shared/templates/Article.vue'
+  import ActionsTemplate from '@/components/shared/templates/Actions.vue'
   import animeList from './data.json'
 
   defineOptions({

--- a/src/pages/entertainment/Entertainment.vue
+++ b/src/pages/entertainment/Entertainment.vue
@@ -1,6 +1,6 @@
 <script setup>
-  import ArticleTemplate from '../../components/shared/templates/Article.vue'
-  import ActionsTemplate from '../../components/shared/templates/Actions.vue'
+  import ArticleTemplate from '@/components/shared/templates/Article.vue'
+  import ActionsTemplate from '@/components/shared/templates/Actions.vue'
 
   defineOptions({
     name: 'EntertainmentTemplate',

--- a/src/pages/entertainment/Movies.vue
+++ b/src/pages/entertainment/Movies.vue
@@ -1,6 +1,6 @@
 <script setup>
-  import ArticleTemplate from '../../components/shared/templates/Article.vue'
-  import ActionsTemplate from '../../components/shared/templates/Actions.vue'
+  import ArticleTemplate from '@/components/shared/templates/Article.vue'
+  import ActionsTemplate from '@/components/shared/templates/Actions.vue'
 
   defineOptions({
     name: 'MoviesTemplate',

--- a/src/pages/experiments/Experiments.vue
+++ b/src/pages/experiments/Experiments.vue
@@ -1,7 +1,7 @@
 <script setup>
-  import ArticleTemplate from '../../components/shared/templates/Article.vue'
-  import SuggestionsTemplate from '../../components/shared/templates/Suggestions.vue'
-  import ActionsTemplate from '../../components/shared/templates/Actions.vue'
+  import ArticleTemplate from '@/components/shared/templates/Article.vue'
+  import SuggestionsTemplate from '@/components/shared/templates/Suggestions.vue'
+  import ActionsTemplate from '@/components/shared/templates/Actions.vue'
   import suggestions from './suggestions.json'
   import experiment1 from './assets/Visinata_Experient_1_2025-06-28.jpeg'
   import experiment2 from './assets/Visinata_Experient_2_2025-06-28.jpeg'

--- a/src/pages/home/Home.vue
+++ b/src/pages/home/Home.vue
@@ -1,6 +1,6 @@
 <script setup>
-  import ArticleTemplate from '../../components/shared/templates/Article.vue'
-  import ActionsTemplate from '../../components/shared/templates/Actions.vue'
+  import ArticleTemplate from '@/components/shared/templates/Article.vue'
+  import ActionsTemplate from '@/components/shared/templates/Actions.vue'
 
   defineOptions({
     name: 'HomeTemplate',

--- a/src/pages/ikigai/Ikigai.vue
+++ b/src/pages/ikigai/Ikigai.vue
@@ -1,7 +1,7 @@
 <script setup>
-  import ArticleTemplate from '../../components/shared/templates/Article.vue'
-  import ActionsTemplate from '../../components/shared/templates/Actions.vue'
-  import SuggestionsTemplate from '../../components/shared/templates/Suggestions.vue'
+  import ArticleTemplate from '@/components/shared/templates/Article.vue'
+  import ActionsTemplate from '@/components/shared/templates/Actions.vue'
+  import SuggestionsTemplate from '@/components/shared/templates/Suggestions.vue'
   import suggestions from './suggestions.json'
 
   defineOptions({

--- a/src/pages/ippo/Ippo.vue
+++ b/src/pages/ippo/Ippo.vue
@@ -1,6 +1,6 @@
 <script setup>
-  import ArticleTemplate from '../../components/shared/templates/Article.vue'
-  import ActionsTemplate from '../../components/shared/templates/Actions.vue'
+  import ArticleTemplate from '@/components/shared/templates/Article.vue'
+  import ActionsTemplate from '@/components/shared/templates/Actions.vue'
 
   defineOptions({
     name: 'IppoTemplate',

--- a/src/pages/literature/Literature.vue
+++ b/src/pages/literature/Literature.vue
@@ -1,6 +1,6 @@
 <script setup>
-  import ArticleTemplate from '../../components/shared/templates/Article.vue'
-  import ActionsTemplate from '../../components/shared/templates/Actions.vue'
+  import ArticleTemplate from '@/components/shared/templates/Article.vue'
+  import ActionsTemplate from '@/components/shared/templates/Actions.vue'
 
   defineOptions({
     name: 'LiteratureTemplate',

--- a/src/pages/literature/books/Books.vue
+++ b/src/pages/literature/books/Books.vue
@@ -1,6 +1,6 @@
 <script setup>
-  import ArticleTemplate from '../../../components/shared/templates/Article.vue'
-  import ActionsTemplate from '../../../components/shared/templates/Actions.vue'
+  import ArticleTemplate from '@/components/shared/templates/Article.vue'
+  import ActionsTemplate from '@/components/shared/templates/Actions.vue'
 
   defineOptions({
     name: 'BooksTemplate',

--- a/src/pages/literature/poems/Poems.vue
+++ b/src/pages/literature/poems/Poems.vue
@@ -1,6 +1,6 @@
 <script setup>
-  import ArticleTemplate from '../../../components/shared/templates/Article.vue'
-  import ActionsTemplate from '../../../components/shared/templates/Actions.vue'
+  import ArticleTemplate from '@/components/shared/templates/Article.vue'
+  import ActionsTemplate from '@/components/shared/templates/Actions.vue'
 
   defineOptions({
     name: 'PoemsTemplate',

--- a/src/pages/nutrition/Nutrition.vue
+++ b/src/pages/nutrition/Nutrition.vue
@@ -1,6 +1,6 @@
 <script setup>
-  import ArticleTemplate from '../../components/shared/templates/Article.vue'
-  import ActionsTemplate from '../../components/shared/templates/Actions.vue'
+  import ArticleTemplate from '@/components/shared/templates/Article.vue'
+  import ActionsTemplate from '@/components/shared/templates/Actions.vue'
 
   defineOptions({
     name: 'NutritionTemplate',

--- a/src/pages/nutrition/ingredients/Ingredients.vue
+++ b/src/pages/nutrition/ingredients/Ingredients.vue
@@ -1,7 +1,7 @@
 <script setup>
   import { ref, computed, watch } from 'vue'
-  import ArticleTemplate from '../../../components/shared/templates/Article.vue'
-  import ActionsTemplate from '../../../components/shared/templates/Actions.vue'
+  import ArticleTemplate from '@/components/shared/templates/Article.vue'
+  import ActionsTemplate from '@/components/shared/templates/Actions.vue'
   import ingredients from './ingredients.json'
 
   defineOptions({

--- a/src/pages/practice/Practice.vue
+++ b/src/pages/practice/Practice.vue
@@ -1,6 +1,6 @@
 <script setup>
-  import ArticleTemplate from '../../components/shared/templates/Article.vue'
-  import ActionsTemplate from '../../components/shared/templates/Actions.vue'
+  import ArticleTemplate from '@/components/shared/templates/Article.vue'
+  import ActionsTemplate from '@/components/shared/templates/Actions.vue'
 
   defineOptions({
     name: 'PracticeTemplate',

--- a/src/pages/practice/routines/Routines.vue
+++ b/src/pages/practice/routines/Routines.vue
@@ -1,6 +1,6 @@
 <script setup>
   import { ref, reactive, computed, onMounted } from 'vue'
-  import ArticleTemplate from '../../../components/shared/templates/Article.vue'
+  import ArticleTemplate from '@/components/shared/templates/Article.vue'
   import habitsData from './habits.json'
   import activitiesData from './activities.json'
 

--- a/src/pages/random/Random.vue
+++ b/src/pages/random/Random.vue
@@ -1,5 +1,5 @@
 <script setup>
-  import ArticleTemplate from '../../components/shared/templates/Article.vue'
+  import ArticleTemplate from '@/components/shared/templates/Article.vue'
 
   defineOptions({
     name: 'RandomTemplate',

--- a/src/router.js
+++ b/src/router.js
@@ -1,7 +1,7 @@
 import { createRouter, createWebHashHistory } from 'vue-router'
-import routes from './routes.js'
-import { useAuthentication } from './composables/useAuthentication.js'
-import { authEvents, AUTH_REQUIRED_EVENT } from './authEvents.js'
+import routes from '@/routes.js'
+import { useAuthentication } from '@/composables/useAuthentication.js'
+import { authEvents, AUTH_REQUIRED_EVENT } from '@/authEvents.js'
 
 /**
  * Create a Vue Router instance with a simple authentication guard.

--- a/src/routes.js
+++ b/src/routes.js
@@ -6,33 +6,33 @@
  * Dynamic imports keep bundle size small and the optional `meta.requiresAuth`
  * flag marks routes that should be hidden behind the password modal.
  */
-const Home = () => import('./pages/home/Home.vue')
-const Ikigai = () => import('./pages/ikigai/Ikigai.vue')
-const Ippo = () => import('./pages/ippo/Ippo.vue')
-const Experiments = () => import('./pages/experiments/Experiments.vue')
-const Random = () => import('./pages/random/Random.vue')
+const Home = () => import('@/pages/home/Home.vue')
+const Ikigai = () => import('@/pages/ikigai/Ikigai.vue')
+const Ippo = () => import('@/pages/ippo/Ippo.vue')
+const Experiments = () => import('@/pages/experiments/Experiments.vue')
+const Random = () => import('@/pages/random/Random.vue')
 
 // Literature Components
-const Literature = () => import('./pages/literature/Literature.vue')
-const Books = () => import('./pages/literature/books/Books.vue')
-const Poems = () => import('./pages/literature/poems/Poems.vue')
+const Literature = () => import('@/pages/literature/Literature.vue')
+const Books = () => import('@/pages/literature/books/Books.vue')
+const Poems = () => import('@/pages/literature/poems/Poems.vue')
 
 // Entertainment Components
-const Entertainment = () => import('./pages/entertainment/Entertainment.vue')
-const Anime = () => import('./pages/entertainment/Anime.vue')
-const Movies = () => import('./pages/entertainment/Movies.vue')
+const Entertainment = () => import('@/pages/entertainment/Entertainment.vue')
+const Anime = () => import('@/pages/entertainment/Anime.vue')
+const Movies = () => import('@/pages/entertainment/Movies.vue')
 
 // Nutrition Components
-const Nutrition = () => import('./pages/nutrition/Nutrition.vue')
-const Ingredients = () => import('./pages/nutrition/ingredients/Ingredients.vue')
+const Nutrition = () => import('@/pages/nutrition/Nutrition.vue')
+const Ingredients = () => import('@/pages/nutrition/ingredients/Ingredients.vue')
 
 // Adventure Components
-const Adventure = () => import('./pages/adventure/Adventure.vue')
-const Destinations = () => import('./pages/adventure/destinations/Destinations.vue')
+const Adventure = () => import('@/pages/adventure/Adventure.vue')
+const Destinations = () => import('@/pages/adventure/destinations/Destinations.vue')
 
 // Practice Components
-const Practice = () => import('./pages/practice/Practice.vue')
-const Routines = () => import('./pages/practice/routines/Routines.vue')
+const Practice = () => import('@/pages/practice/Practice.vue')
+const Routines = () => import('@/pages/practice/routines/Routines.vue')
 
 export default [
   { path: '/', component: Home, meta: { label: 'Home', group: null, requiresAuth: false } },

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,9 +1,13 @@
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
+import path from 'node:path'
 
 export default defineConfig({
-  base: '/small-steps/', 
+  base: '/small-steps/',
   plugins: [vue()],
+  resolve: {
+    alias: { '@': path.resolve(__dirname, 'src') }
+  },
   server: {
     port: 8080
   },


### PR DESCRIPTION
## Summary
- map `@` to `src` in Vite config
- use the `@` alias instead of long relative paths

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68963f231e1c83238ec47048bf86f6c1