### PR TITLE
Organize tests to mirror src layout

### DIFF
--- a/src/composables/useAuthentication.js
+++ b/src/composables/useAuthentication.js
@@ -1,5 +1,5 @@
 import { ref, computed, watchEffect } from 'vue'
-import routes from '@/routes.js'
+import routes from '../routes.js'
 
 // Password from environment variable (fallback to process.env for tests)
 const CORRECT_PASSWORD = import.meta.env?.VITE_APP_PASSWORD || globalThis.process?.env?.VITE_APP_PASSWORD

--- a/src/router.js
+++ b/src/router.js
@@ -1,7 +1,7 @@
 import { createRouter, createWebHashHistory } from 'vue-router'
-import routes from '@/routes.js'
-import { useAuthentication } from '@/composables/useAuthentication.js'
-import { authEvents, AUTH_REQUIRED_EVENT } from '@/authEvents.js'
+import routes from './routes.js'
+import { useAuthentication } from './composables/useAuthentication.js'
+import { authEvents, AUTH_REQUIRED_EVENT } from './authEvents.js'
 
 /**
  * Create a Vue Router instance with a simple authentication guard.

--- a/tests/composables/useAuthentication.test.js
+++ b/tests/composables/useAuthentication.test.js
@@ -16,7 +16,7 @@ test('initializes from existing session token and clears on logout', async (t) =
   setupTestEnvironment(t)
   sessionStorage.setItem('memento-mori-authentication', 'true')
   const { useAuthentication } = await import(
-    '../src/composables/useAuthentication.js?from-session'
+    '../../src/composables/useAuthentication.js?from-session'
   )
   const auth = useAuthentication()
   assert.equal(auth.isAuthenticated.value, true)

--- a/tests/pages/adventure/adventure.test.js
+++ b/tests/pages/adventure/adventure.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { renderComponent, resolveRoute } from '../../pageTestUtils.js'
+import { renderComponent, resolveRoute } from '../pageTestUtils.js'
 
 const file = 'src/pages/adventure/Adventure.vue'
 const path = '/adventure'

--- a/tests/pages/adventure/destinations/destinations.test.js
+++ b/tests/pages/adventure/destinations/destinations.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { renderComponent, resolveRoute } from '../../../pageTestUtils.js'
+import { renderComponent, resolveRoute } from '../../pageTestUtils.js'
 
 const file = 'src/pages/adventure/destinations/Destinations.vue'
 const path = '/adventure/destinations'

--- a/tests/pages/entertainment/entertainment.test.js
+++ b/tests/pages/entertainment/entertainment.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { renderComponent, resolveRoute } from '../../pageTestUtils.js'
+import { renderComponent, resolveRoute } from '../pageTestUtils.js'
 import path from 'node:path'
 
 const pages = [

--- a/tests/pages/experiments/experiments.test.js
+++ b/tests/pages/experiments/experiments.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { renderComponent, resolveRoute } from '../../pageTestUtils.js'
+import { renderComponent, resolveRoute } from '../pageTestUtils.js'
 
 const file = 'src/pages/experiments/Experiments.vue'
 const path = '/experiments'

--- a/tests/pages/home/home.test.js
+++ b/tests/pages/home/home.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { renderComponent, resolveRoute } from '../../pageTestUtils.js'
+import { renderComponent, resolveRoute } from '../pageTestUtils.js'
 
 const file = 'src/pages/home/Home.vue'
 const path = '/'

--- a/tests/pages/ikigai/ikigai.test.js
+++ b/tests/pages/ikigai/ikigai.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { renderComponent, resolveRoute } from '../../pageTestUtils.js'
+import { renderComponent, resolveRoute } from '../pageTestUtils.js'
 
 const file = 'src/pages/ikigai/Ikigai.vue'
 const path = '/ikigai'

--- a/tests/pages/ippo/ippo.test.js
+++ b/tests/pages/ippo/ippo.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { renderComponent, resolveRoute } from '../../pageTestUtils.js'
+import { renderComponent, resolveRoute } from '../pageTestUtils.js'
 
 const file = 'src/pages/ippo/Ippo.vue'
 const path = '/ippo'

--- a/tests/pages/literature/books/books.test.js
+++ b/tests/pages/literature/books/books.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { renderComponent, resolveRoute } from '../../../pageTestUtils.js'
+import { renderComponent, resolveRoute } from '../../pageTestUtils.js'
 
 const file = 'src/pages/literature/books/Books.vue'
 const path = '/books'

--- a/tests/pages/literature/literature.test.js
+++ b/tests/pages/literature/literature.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { renderComponent, resolveRoute } from '../../pageTestUtils.js'
+import { renderComponent, resolveRoute } from '../pageTestUtils.js'
 
 const file = 'src/pages/literature/Literature.vue'
 const path = '/literature'

--- a/tests/pages/literature/poems/poems.test.js
+++ b/tests/pages/literature/poems/poems.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { renderComponent, resolveRoute } from '../../../pageTestUtils.js'
+import { renderComponent, resolveRoute } from '../../pageTestUtils.js'
 
 const file = 'src/pages/literature/poems/Poems.vue'
 const path = '/poems'

--- a/tests/pages/nutrition/ingredients/ingredients.test.js
+++ b/tests/pages/nutrition/ingredients/ingredients.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { renderComponent, resolveRoute } from '../../../pageTestUtils.js'
+import { renderComponent, resolveRoute } from '../../pageTestUtils.js'
 
 const file = 'src/pages/nutrition/ingredients/Ingredients.vue'
 const path = '/nutrition/ingredients'

--- a/tests/pages/nutrition/nutrition.test.js
+++ b/tests/pages/nutrition/nutrition.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { renderComponent, resolveRoute } from '../../pageTestUtils.js'
+import { renderComponent, resolveRoute } from '../pageTestUtils.js'
 
 const file = 'src/pages/nutrition/Nutrition.vue'
 const path = '/nutrition'

--- a/tests/pages/pageTestUtils.js
+++ b/tests/pages/pageTestUtils.js
@@ -4,7 +4,7 @@ import { parse, compileScript, compileTemplate } from '@vue/compiler-sfc'
 import * as Vue from 'vue'
 import { createSSRApp } from 'vue'
 import { renderToString } from 'vue/server-renderer'
-import rawRoutes from '../src/routes.js'
+import rawRoutes from '../../src/routes.js'
 import { createMemoryHistory } from 'vue-router'
 
 /**
@@ -54,9 +54,9 @@ export async function resolveRoute(pathName, authenticated = false) {
   process.env.VITE_APP_PASSWORD = 'secret'
 
   const routes = rawRoutes.map((r) => ({ ...r, component: {} }))
-  const { createAppRouter } = await import('../src/router.js')
+  const { createAppRouter } = await import('../../src/router.js')
   const router = createAppRouter(createMemoryHistory(), routes)
-  const { useAuthentication } = await import('../src/composables/useAuthentication.js')
+  const { useAuthentication } = await import('../../src/composables/useAuthentication.js')
   const auth = useAuthentication()
   auth.logout()
   if (authenticated) auth.authenticate('secret')

--- a/tests/pages/practice/practice.test.js
+++ b/tests/pages/practice/practice.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { renderComponent, resolveRoute } from '../../pageTestUtils.js'
+import { renderComponent, resolveRoute } from '../pageTestUtils.js'
 
 const file = 'src/pages/practice/Practice.vue'
 const path = '/practice'

--- a/tests/pages/practice/routines/routines.test.js
+++ b/tests/pages/practice/routines/routines.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { renderComponent, resolveRoute } from '../../../pageTestUtils.js'
+import { renderComponent, resolveRoute } from '../../pageTestUtils.js'
 
 const file = 'src/pages/practice/routines/Routines.vue'
 const path = '/practice/routines'

--- a/tests/pages/random/random.test.js
+++ b/tests/pages/random/random.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { renderComponent, resolveRoute } from '../../pageTestUtils.js'
+import { renderComponent, resolveRoute } from '../pageTestUtils.js'
 
 const file = 'src/pages/random/Random.vue'
 const path = '/random'

--- a/tests/router/router.test.js
+++ b/tests/router/router.test.js
@@ -1,15 +1,15 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import { createMemoryHistory } from 'vue-router'
-import rawRoutes from '../src/routes.js'
-import { authEvents, AUTH_REQUIRED_EVENT } from '../src/authEvents.js'
-import { setupTestEnvironment, PASSWORD } from './testUtils.js'
+import rawRoutes from '../../src/routes.js'
+import { authEvents, AUTH_REQUIRED_EVENT } from '../../src/authEvents.js'
+import { setupTestEnvironment, PASSWORD } from '../testUtils.js'
 
 async function setup(t, authenticated = false) {
   setupTestEnvironment(t)
 
-  const { useAuthentication } = await import('../src/composables/useAuthentication.js')
-  const { createAppRouter } = await import('../src/router.js')
+  const { useAuthentication } = await import('../../src/composables/useAuthentication.js')
+  const { createAppRouter } = await import('../../src/router.js')
 
   // Stub components to avoid loading .vue files
   const routes = rawRoutes.map((route) => ({ ...route, component: {} }))


### PR DESCRIPTION
## Summary
- move router tests into `tests/router` and update imports
- relocate page test utilities into `tests/pages` and adjust page tests
- use relative paths instead of `@` alias in `useAuthentication` and router modules

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896427fcfbc8323aabe6982f83fba01