### PR TITLE
Refactor variable names for clarity

### DIFF
--- a/src/composables/useAuthentication.js
+++ b/src/composables/useAuthentication.js
@@ -1,5 +1,5 @@
 import { ref, computed, watchEffect } from 'vue'
-import routes from '@/routes.js'
+import routes from '../routes.js'
 
 // Password from environment variable (fallback to process.env for tests)
 const CORRECT_PASSWORD = import.meta.env?.VITE_APP_PASSWORD || globalThis.process?.env?.VITE_APP_PASSWORD
@@ -12,9 +12,9 @@ if (!CORRECT_PASSWORD) {
 const isAuthenticated = ref(false)
 
 // Build a lookup of route metadata for quick access checks
-const routeMeta = routes.reduce((acc, route) => {
-  acc[route.path] = route.meta || {}
-  return acc
+const routeMeta = routes.reduce((metaByPath, route) => {
+  metaByPath[route.path] = route.meta || {}
+  return metaByPath
 }, {})
 
 // Check sessionStorage on composable creation and watch for changes
@@ -92,36 +92,36 @@ export function useAuthentication() {
         label: route.meta?.label || route.path,
         public: !route.meta?.requiresAuth,
       }))
-      .filter((item) => item.public || isAuthenticated.value)
+      .filter((navigationItem) => navigationItem.public || isAuthenticated.value)
   })
 
   const dropdownSections = computed(() => {
-    const sections = {}
+    const sectionsByGroup = {}
     routes.forEach((route) => {
       const meta = route.meta || {}
       if (!meta.group) return
 
-      if (!sections[meta.group]) {
-        sections[meta.group] = {
+      if (!sectionsByGroup[meta.group]) {
+        sectionsByGroup[meta.group] = {
           label: meta.group.charAt(0).toUpperCase() + meta.group.slice(1),
           public: !meta.requiresAuth,
           items: [],
         }
       }
 
-      sections[meta.group].public = sections[meta.group].public && !meta.requiresAuth
-      sections[meta.group].items.push({ path: route.path, label: meta.label })
+      sectionsByGroup[meta.group].public = sectionsByGroup[meta.group].public && !meta.requiresAuth
+      sectionsByGroup[meta.group].items.push({ path: route.path, label: meta.label })
     })
 
-    const filteredSections = {}
-    Object.keys(sections).forEach((key) => {
-      const section = sections[key]
-      if (section.public || isAuthenticated.value) {
-        filteredSections[key] = section
+    const visibleSections = {}
+    Object.keys(sectionsByGroup).forEach((sectionName) => {
+      const sectionDetails = sectionsByGroup[sectionName]
+      if (sectionDetails.public || isAuthenticated.value) {
+        visibleSections[sectionName] = sectionDetails
       }
     })
 
-    return filteredSections
+    return visibleSections
   })
 
   return {

--- a/src/pages/practice/routines/Routines.vue
+++ b/src/pages/practice/routines/Routines.vue
@@ -316,13 +316,13 @@ Contrast verification (AA):
 
       case 'week': {
         // Calculate ISO week number and associated week-year
-        const temp = new Date(date)
-        temp.setHours(0, 0, 0, 0)
-        const day = temp.getDay() || 7 // ISO: Mon=1, Sun=7
-        temp.setDate(temp.getDate() + 4 - day) // Move to Thursday to determine week-year
-        const weekYear = temp.getFullYear()
+        const weekCalculationDate = new Date(date)
+        weekCalculationDate.setHours(0, 0, 0, 0)
+        const isoWeekDay = weekCalculationDate.getDay() || 7 // ISO: Mon=1, Sun=7
+        weekCalculationDate.setDate(weekCalculationDate.getDate() + 4 - isoWeekDay) // Move to Thursday to determine week-year
+        const weekYear = weekCalculationDate.getFullYear()
         const yearStart = new Date(weekYear, 0, 1)
-        const weekNum = Math.ceil(((temp - yearStart) / 86400000 + 1) / 7)
+        const weekNum = Math.ceil(((weekCalculationDate - yearStart) / 86400000 + 1) / 7)
         return `${weekYear}-W${weekNum.toString().padStart(2, '0')}`
       }
 

--- a/tests/composables/useAuthentication.test.js
+++ b/tests/composables/useAuthentication.test.js
@@ -16,7 +16,7 @@ test('initializes from existing session token and clears on logout', async (t) =
   setupTestEnvironment(t)
   sessionStorage.setItem('memento-mori-authentication', 'true')
   const { useAuthentication } = await import(
-    '../src/composables/useAuthentication.js?from-session'
+    '../../src/composables/useAuthentication.js?from-session'
   )
   const auth = useAuthentication()
   assert.equal(auth.isAuthenticated.value, true)


### PR DESCRIPTION
## Summary
- rename auth route metadata accumulator to `metaByPath` and clarify section grouping logic
- clarify ISO week calculations with explicit `weekCalculationDate` and `isoWeekDay` variables
- fix test path resolution for authentication composable

## Testing
- `npm test >/tmp/unit.log; tail -n 20 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_689643ec9a7c8323b91c3f061f9a9bfe