### PR TITLE
Lazy-load Leaflet in Destinations map

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -13,6 +13,7 @@ module.exports = [
       '*.config.js',
       '*.config.cjs',
       'eslint-wide-formatter.js',
+      'eslint-wide-formatter.cjs',
     ],
   },
   {

--- a/src/pages/adventure/destinations/Destinations.vue
+++ b/src/pages/adventure/destinations/Destinations.vue
@@ -1,7 +1,5 @@
 <script setup>
   import { onMounted, ref, nextTick, computed } from 'vue'
-  import L from 'leaflet'
-  import 'leaflet/dist/leaflet.css'
   import ArticleTemplate from '@/components/shared/templates/Article.vue'
   import ActionsTemplate from '@/components/shared/templates/Actions.vue'
   import destinationsData from './destinations.json'
@@ -180,7 +178,7 @@
     return cachedGeoData.value
   }
 
-  const initializeMap = async () => {
+  const initializeMap = async (L) => {
     try {
       // Load GeoJSON data with caching
       const worldData = await fetchWorldData()
@@ -259,8 +257,10 @@
     }
   }
 
-  onMounted(() => {
-    initializeMap()
+  onMounted(async () => {
+    const { default: L } = await import('leaflet')
+    await import('leaflet/dist/leaflet.css')
+    await initializeMap(L)
   })
 </script>
 


### PR DESCRIPTION
## Summary
- dynamically import Leaflet and styles on mount for Destinations map
- ignore custom ESLint formatter file to prevent lint errors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896469ca2b883239c8cc8bff7e38350