### PR TITLE
feat: run page tests with vitest jsdom

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "fix": "npm run lint:fix && npm run format",
-    "test": "node --test --experimental-test-coverage tests/**/*.js && npm run lint",
+    "test": "node --test --experimental-test-coverage tests/components/**/*.js tests/composables/**/*.js tests/router/**/*.js && vitest run tests/pages/**/*.test.js && npm run lint",
     "predeploy": "npm run build",
     "deploy": "gh-pages -d dist"
   },
@@ -40,6 +40,8 @@
     "sass": "^1.89.0",
     "sass-loader": "^16.0.5",
     "vite": "^6.3.5",
-    "vue-loader": "^17.4.2"
+    "vue-loader": "^17.4.2",
+    "@vue/test-utils": "^2.4.5",
+    "vitest": "^1.6.0"
   }
 }

--- a/tests/pages/adventure/adventure.test.js
+++ b/tests/pages/adventure/adventure.test.js
@@ -1,5 +1,4 @@
-import test from 'node:test'
-import assert from 'node:assert/strict'
+import { test, expect } from 'vitest'
 import { renderComponent, resolveRoute } from '../pageTestUtils.js'
 
 const file = 'src/pages/adventure/Adventure.vue'
@@ -7,10 +6,10 @@ const path = '/adventure'
 
 test('Adventure page renders without errors', async () => {
   const html = await renderComponent(file)
-  assert.ok(html.length > 0)
+  expect(html.length).toBeGreaterThan(0)
 })
 
 test('Adventure route resolves', async () => {
   const resolved = await resolveRoute(path)
-  assert.equal(resolved, path)
+  expect(resolved).toBe(path)
 })

--- a/tests/pages/adventure/destinations/destinations.test.js
+++ b/tests/pages/adventure/destinations/destinations.test.js
@@ -1,5 +1,4 @@
-import test from 'node:test'
-import assert from 'node:assert/strict'
+import { test, expect } from 'vitest'
 import { renderComponent, resolveRoute } from '../../pageTestUtils.js'
 
 const file = 'src/pages/adventure/destinations/Destinations.vue'
@@ -7,10 +6,10 @@ const path = '/adventure/destinations'
 
 test('Destinations page renders without errors', async () => {
   const html = await renderComponent(file)
-  assert.ok(html.length > 0)
+  expect(html.length).toBeGreaterThan(0)
 })
 
 test('Destinations route resolves', async () => {
   const resolved = await resolveRoute(path)
-  assert.equal(resolved, path)
+  expect(resolved).toBe(path)
 })

--- a/tests/pages/entertainment/entertainment.test.js
+++ b/tests/pages/entertainment/entertainment.test.js
@@ -1,5 +1,4 @@
-import test from 'node:test'
-import assert from 'node:assert/strict'
+import { test, expect } from 'vitest'
 import { renderComponent, resolveRoute } from '../pageTestUtils.js'
 import path from 'node:path'
 
@@ -13,11 +12,11 @@ for (const { file, route } of pages) {
   const name = path.basename(file)
   test(`${name} renders without errors`, async () => {
     const html = await renderComponent(file)
-    assert.ok(html.length > 0)
+    expect(html.length).toBeGreaterThan(0)
   })
 
   test(`route ${route} resolves`, async () => {
     const resolved = await resolveRoute(route)
-    assert.equal(resolved, route)
+    expect(resolved).toBe(route)
   })
 }

--- a/tests/pages/experiments/experiments.test.js
+++ b/tests/pages/experiments/experiments.test.js
@@ -1,5 +1,4 @@
-import test from 'node:test'
-import assert from 'node:assert/strict'
+import { test, expect } from 'vitest'
 import { renderComponent, resolveRoute } from '../pageTestUtils.js'
 
 const file = 'src/pages/experiments/Experiments.vue'
@@ -7,10 +6,10 @@ const path = '/experiments'
 
 test('Experiments page renders without errors', async () => {
   const html = await renderComponent(file)
-  assert.ok(html.length > 0)
+  expect(html.length).toBeGreaterThan(0)
 })
 
 test('Experiments route resolves', async () => {
   const resolved = await resolveRoute(path, true)
-  assert.equal(resolved, path)
+  expect(resolved).toBe(path)
 })

--- a/tests/pages/home/home.test.js
+++ b/tests/pages/home/home.test.js
@@ -1,5 +1,4 @@
-import test from 'node:test'
-import assert from 'node:assert/strict'
+import { test, expect } from 'vitest'
 import { renderComponent, resolveRoute } from '../pageTestUtils.js'
 
 const file = 'src/pages/home/Home.vue'
@@ -7,10 +6,10 @@ const path = '/'
 
 test('Home page renders without errors', async () => {
   const html = await renderComponent(file)
-  assert.ok(html.length > 0)
+  expect(html.length).toBeGreaterThan(0)
 })
 
 test('Home route resolves', async () => {
   const resolved = await resolveRoute(path)
-  assert.equal(resolved, path)
+  expect(resolved).toBe(path)
 })

--- a/tests/pages/ikigai/ikigai.test.js
+++ b/tests/pages/ikigai/ikigai.test.js
@@ -1,5 +1,4 @@
-import test from 'node:test'
-import assert from 'node:assert/strict'
+import { test, expect } from 'vitest'
 import { renderComponent, resolveRoute } from '../pageTestUtils.js'
 
 const file = 'src/pages/ikigai/Ikigai.vue'
@@ -7,10 +6,10 @@ const path = '/ikigai'
 
 test('Ikigai page renders without errors', async () => {
   const html = await renderComponent(file)
-  assert.ok(html.length > 0)
+  expect(html.length).toBeGreaterThan(0)
 })
 
 test('Ikigai route resolves', async () => {
   const resolved = await resolveRoute(path, true)
-  assert.equal(resolved, path)
+  expect(resolved).toBe(path)
 })

--- a/tests/pages/ippo/ippo.test.js
+++ b/tests/pages/ippo/ippo.test.js
@@ -1,5 +1,4 @@
-import test from 'node:test'
-import assert from 'node:assert/strict'
+import { test, expect } from 'vitest'
 import { renderComponent, resolveRoute } from '../pageTestUtils.js'
 
 const file = 'src/pages/ippo/Ippo.vue'
@@ -7,10 +6,10 @@ const path = '/ippo'
 
 test('Ippo page renders without errors', async () => {
   const html = await renderComponent(file)
-  assert.ok(html.length > 0)
+  expect(html.length).toBeGreaterThan(0)
 })
 
 test('Ippo route resolves', async () => {
   const resolved = await resolveRoute(path, true)
-  assert.equal(resolved, path)
+  expect(resolved).toBe(path)
 })

--- a/tests/pages/literature/books/books.test.js
+++ b/tests/pages/literature/books/books.test.js
@@ -1,5 +1,4 @@
-import test from 'node:test'
-import assert from 'node:assert/strict'
+import { test, expect } from 'vitest'
 import { renderComponent, resolveRoute } from '../../pageTestUtils.js'
 
 const file = 'src/pages/literature/books/Books.vue'
@@ -7,10 +6,10 @@ const path = '/books'
 
 test('Books page renders without errors', async () => {
   const html = await renderComponent(file)
-  assert.ok(html.length > 0)
+  expect(html.length).toBeGreaterThan(0)
 })
 
 test('Books route resolves', async () => {
   const resolved = await resolveRoute(path)
-  assert.equal(resolved, path)
+  expect(resolved).toBe(path)
 })

--- a/tests/pages/literature/literature.test.js
+++ b/tests/pages/literature/literature.test.js
@@ -1,5 +1,4 @@
-import test from 'node:test'
-import assert from 'node:assert/strict'
+import { test, expect } from 'vitest'
 import { renderComponent, resolveRoute } from '../pageTestUtils.js'
 
 const file = 'src/pages/literature/Literature.vue'
@@ -7,10 +6,10 @@ const path = '/literature'
 
 test('Literature page renders without errors', async () => {
   const html = await renderComponent(file)
-  assert.ok(html.length > 0)
+  expect(html.length).toBeGreaterThan(0)
 })
 
 test('Literature route resolves', async () => {
   const resolved = await resolveRoute(path)
-  assert.equal(resolved, path)
+  expect(resolved).toBe(path)
 })

--- a/tests/pages/literature/poems/poems.test.js
+++ b/tests/pages/literature/poems/poems.test.js
@@ -1,5 +1,4 @@
-import test from 'node:test'
-import assert from 'node:assert/strict'
+import { test, expect } from 'vitest'
 import { renderComponent, resolveRoute } from '../../pageTestUtils.js'
 
 const file = 'src/pages/literature/poems/Poems.vue'
@@ -7,10 +6,10 @@ const path = '/poems'
 
 test('Poems page renders without errors', async () => {
   const html = await renderComponent(file)
-  assert.ok(html.length > 0)
+  expect(html.length).toBeGreaterThan(0)
 })
 
 test('Poems route resolves', async () => {
   const resolved = await resolveRoute(path)
-  assert.equal(resolved, path)
+  expect(resolved).toBe(path)
 })

--- a/tests/pages/nutrition/ingredients/ingredients.test.js
+++ b/tests/pages/nutrition/ingredients/ingredients.test.js
@@ -1,5 +1,4 @@
-import test from 'node:test'
-import assert from 'node:assert/strict'
+import { test, expect } from 'vitest'
 import { renderComponent, resolveRoute } from '../../pageTestUtils.js'
 
 const file = 'src/pages/nutrition/ingredients/Ingredients.vue'
@@ -7,10 +6,10 @@ const path = '/nutrition/ingredients'
 
 test('Ingredients page renders without errors', async () => {
   const html = await renderComponent(file)
-  assert.ok(html.length > 0)
+  expect(html.length).toBeGreaterThan(0)
 })
 
 test('Ingredients route resolves', async () => {
   const resolved = await resolveRoute(path)
-  assert.equal(resolved, path)
+  expect(resolved).toBe(path)
 })

--- a/tests/pages/nutrition/nutrition.test.js
+++ b/tests/pages/nutrition/nutrition.test.js
@@ -1,5 +1,4 @@
-import test from 'node:test'
-import assert from 'node:assert/strict'
+import { test, expect } from 'vitest'
 import { renderComponent, resolveRoute } from '../pageTestUtils.js'
 
 const file = 'src/pages/nutrition/Nutrition.vue'
@@ -7,10 +6,10 @@ const path = '/nutrition'
 
 test('Nutrition page renders without errors', async () => {
   const html = await renderComponent(file)
-  assert.ok(html.length > 0)
+  expect(html.length).toBeGreaterThan(0)
 })
 
 test('Nutrition route resolves', async () => {
   const resolved = await resolveRoute(path)
-  assert.equal(resolved, path)
+  expect(resolved).toBe(path)
 })

--- a/tests/pages/pageTestUtils.js
+++ b/tests/pages/pageTestUtils.js
@@ -1,96 +1,22 @@
-import { readFileSync } from 'node:fs'
 import path from 'node:path'
-import { parse, compileScript, compileTemplate } from '@vue/compiler-sfc'
-import * as Vue from 'vue'
-import { createSSRApp } from 'vue'
-import { renderToString } from 'vue/server-renderer'
+import { shallowMount } from '@vue/test-utils'
 import rawRoutes from '../../src/configuration/routes.js'
 import { createMemoryHistory } from 'vue-router'
 
 /**
- * Compile and render a Vue Single File Component to string.
- * Imports are replaced with empty stubs to avoid loading child components.
+ * Render a Vue component using shallowMount with child components stubbed.
  * @param {string} file - Path to the .vue file relative to project root.
  * @returns {Promise<string>} rendered HTML string
  */
 export async function renderComponent(file) {
   const filePath = path.resolve(file)
-  const src = readFileSync(filePath, 'utf-8')
-  const { descriptor } = parse(src, { filename: filePath })
-  
-  let script = compileScript(descriptor, { id: filePath }).content
-  
-  // More comprehensive import replacement patterns
-  // Handle various import patterns: default, named, mixed, side effects
-  script = script.replace(/import\s+(\w+)\s*,\s*\{([^}]+)\}\s+from\s+['"][^'"]+['"];?\n?/g, 'const $1 = {}; const { $2 } = {};\n')
-  script = script.replace(/import\s+\{([^}]+)\}\s+from\s+['"][^'"]+['"];?\n?/g, 'const { $1 } = {};\n')
-  script = script.replace(/import\s+(\w+)\s+from\s+['"][^'"]+['"];?\n?/g, 'const $1 = {};\n')
-  script = script.replace(/import\s+['"][^'"]+['"];?\n?/g, '') // Side effect imports
-  
-  // Handle path aliases - resolve @/ to src/
-  script = script.replace(/@\//g, path.resolve('src') + '/')
-  
-  // Handle import.meta references
-  script = script.replace(/import\.meta\.env\.BASE_URL/g, "'/'")
-  script = script.replace(/import\.meta\.env\.DEV/g, "false")
-  script = script.replace(/import\.meta\.env/g, "{ BASE_URL: '/', DEV: false }")
-  script = script.replace(/import\.meta/g, "{ env: { BASE_URL: '/', DEV: false } }")
-  
-  // Replace export default
-  script = script.replace('export default', 'const __default__ =')
-  
-  // Add safer template compilation with better error handling
-  let template
-  try {
-    template = compileTemplate({
-      source: descriptor.template?.content || '<div>No template</div>',
-      filename: filePath,
-      id: filePath,
-      compilerOptions: { 
-        mode: 'function',
-        hoistStatic: false,
-        cacheHandlers: false
-      },
-    })
-  } catch {
-    // Template compilation failed
-    template = { code: 'function render() { return Vue.h("div", "Template compilation failed") }' }
-  }
-  
-  // Safer code generation with better error handling
-  const code = `
-    try {
-      ${script}
-      ${template.code}
-      return { ...__default__, render }
-    } catch (error) {
-      // Component compilation error
-      return {
-        name: 'FailedComponent',
-        render: () => Vue.h('div', 'Component failed to compile')
-      }
+  const component = (await import(filePath)).default
+  const wrapper = shallowMount(component, {
+    global: {
+      stubs: { RouterLink: true, RouterView: true }
     }
-  `
-  
-  let component
-  try {
-    component = new Function('Vue', 'path', code)(Vue, path)
-  } catch {
-    // Script compilation failed
-    component = {
-      name: 'FailedComponent',
-      render: () => Vue.h('div', `Failed to compile: ${path.basename(file)}`)
-    }
-  }
-  
-  const app = createSSRApp(component)
-  
-  try {
-    return await renderToString(app)
-  } catch {
-    // Render failed
-    return `<div>Failed to render: ${path.basename(file)}</div>`
-  }
+  })
+  return wrapper.html()
 }
 
 /**

--- a/tests/pages/practice/practice.test.js
+++ b/tests/pages/practice/practice.test.js
@@ -1,5 +1,4 @@
-import test from 'node:test'
-import assert from 'node:assert/strict'
+import { test, expect } from 'vitest'
 import { renderComponent, resolveRoute } from '../pageTestUtils.js'
 
 const file = 'src/pages/practice/Practice.vue'
@@ -7,10 +6,10 @@ const path = '/practice'
 
 test('Practice page renders without errors', async () => {
   const html = await renderComponent(file)
-  assert.ok(html.length > 0)
+  expect(html.length).toBeGreaterThan(0)
 })
 
 test('Practice route resolves', async () => {
   const resolved = await resolveRoute(path, true)
-  assert.equal(resolved, path)
+  expect(resolved).toBe(path)
 })

--- a/tests/pages/practice/routines/routines.test.js
+++ b/tests/pages/practice/routines/routines.test.js
@@ -1,5 +1,4 @@
-import test from 'node:test'
-import assert from 'node:assert/strict'
+import { test, expect } from 'vitest'
 import { renderComponent, resolveRoute } from '../../pageTestUtils.js'
 
 const file = 'src/pages/practice/routines/Routines.vue'
@@ -7,10 +6,10 @@ const path = '/practice/routines'
 
 test('Routines page renders without errors', async () => {
   const html = await renderComponent(file)
-  assert.ok(html.length > 0)
+  expect(html.length).toBeGreaterThan(0)
 })
 
 test('Routines route resolves', async () => {
   const resolved = await resolveRoute(path, true)
-  assert.equal(resolved, path)
+  expect(resolved).toBe(path)
 })

--- a/tests/pages/random/random.test.js
+++ b/tests/pages/random/random.test.js
@@ -1,5 +1,4 @@
-import test from 'node:test'
-import assert from 'node:assert/strict'
+import { test, expect } from 'vitest'
 import { renderComponent, resolveRoute } from '../pageTestUtils.js'
 
 const file = 'src/pages/random/Random.vue'
@@ -7,10 +6,10 @@ const path = '/random'
 
 test('Random page renders without errors', async () => {
   const html = await renderComponent(file)
-  assert.ok(html.length > 0)
+  expect(html.length).toBeGreaterThan(0)
 })
 
 test('Random route resolves', async () => {
   const resolved = await resolveRoute(path, true)
-  assert.equal(resolved, path)
+  expect(resolved).toBe(path)
 })

--- a/vite.config.js
+++ b/vite.config.js
@@ -27,5 +27,8 @@ export default defineConfig({
   define: {
     // Ensure environment variables are available
     'process.env': process.env
+  },
+  test: {
+    environment: 'jsdom'
   }
 })


### PR DESCRIPTION
## Summary
- replace custom SFC compiler with @vue/test-utils shallow mounting
- migrate page suites to Vitest and stub child components
- configure Vitest with jsdom and expose new test script

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68965012c2c08323ae20deee058b9f15