### PR TITLE
Prevent duplicate route prefetching

### DIFF
--- a/src/components/layout/navigation/AppNavigation.vue
+++ b/src/components/layout/navigation/AppNavigation.vue
@@ -13,8 +13,12 @@
   const { isAuthenticated, navigationItems, dropdownSections, logout } = useAuthentication()
   const router = useRouter()
 
+  const prefetched = new Set()
   let prefetchTimer
   const prefetch = (path) => {
+    if (prefetched.has(path)) {
+      return
+    }
     clearTimeout(prefetchTimer)
     prefetchTimer = setTimeout(() => {
       const route = router.resolve(path)
@@ -24,6 +28,7 @@
           component()
         }
       })
+      prefetched.add(path)
     }, 150)
   }
 


### PR DESCRIPTION
## Summary
- track prefetched navigation paths to avoid redundant prefetching

## Testing
- `VITE_SUPABASE_URL='http://example.com' VITE_SUPABASE_ANON_KEY='test' npm test`

------
https://chatgpt.com/codex/tasks/task_e_68965b6f53288323a4f6bea65a1f201d