### PR TITLE
Centralize env getters and mock in tests

### DIFF
--- a/src/configuration/authentication/useAuthentication.js
+++ b/src/configuration/authentication/useAuthentication.js
@@ -1,5 +1,6 @@
 import { ref, computed, watchEffect } from 'vue'
 import routes from '../routes.js'
+import { env } from '../env.js'
 
 // Reactive authentication state
 const isAuthenticated = ref(false)
@@ -52,9 +53,8 @@ watchEffect(() => {
  * }} reactive auth helpers and route guards
  */
 export function useAuthentication() {
-  // Password from environment variable (fallback to process.env for tests)
-  const CORRECT_PASSWORD =
-    import.meta.env?.VITE_APP_PASSWORD || globalThis.process?.env?.VITE_APP_PASSWORD
+  // Password from environment variable via getter
+  const CORRECT_PASSWORD = env.getViteAppPassword()
 
   const authenticate = (password) => {
     if (!CORRECT_PASSWORD) {

--- a/src/configuration/env.js
+++ b/src/configuration/env.js
@@ -1,0 +1,10 @@
+export const env = {
+  getViteAppPassword: () =>
+    import.meta.env?.VITE_APP_PASSWORD ?? globalThis.process?.env?.VITE_APP_PASSWORD,
+  getViteSupabaseUrl: () =>
+    import.meta.env?.VITE_SUPABASE_URL ?? globalThis.process?.env?.VITE_SUPABASE_URL,
+  getViteSupabaseAnonKey: () =>
+    import.meta.env?.VITE_SUPABASE_ANON_KEY ?? globalThis.process?.env?.VITE_SUPABASE_ANON_KEY,
+}
+
+export const { getViteAppPassword, getViteSupabaseUrl, getViteSupabaseAnonKey } = env

--- a/src/configuration/supabase.js
+++ b/src/configuration/supabase.js
@@ -1,5 +1,5 @@
-/* global process */
 import { createClient } from '@supabase/supabase-js'
+import { env } from './env.js'
 
 /**
  * Initialise and export a configured Supabase client.
@@ -12,8 +12,8 @@ import { createClient } from '@supabase/supabase-js'
  * @returns {import('@supabase/supabase-js').SupabaseClient} ready-to-use client
  */
 // Environment variables with fallbacks for development and testing
-const supabaseUrl = import.meta.env?.VITE_SUPABASE_URL || process.env.VITE_SUPABASE_URL
-const supabaseKey = import.meta.env?.VITE_SUPABASE_ANON_KEY || process.env.VITE_SUPABASE_ANON_KEY
+const supabaseUrl = env.getViteSupabaseUrl()
+const supabaseKey = env.getViteSupabaseAnonKey()
 
 // Validate required environment variables
 if (!supabaseUrl) {

--- a/tests/pages/pageTestUtils.js
+++ b/tests/pages/pageTestUtils.js
@@ -1,6 +1,18 @@
 import { mount } from '@vue/test-utils'
 import { createRouter, createMemoryHistory } from 'vue-router'
 import rawRoutes from '../../src/configuration/routes.js'
+import { vi } from 'vitest'
+
+vi.mock('../../src/configuration/env.js', () => ({
+  env: {
+    getViteAppPassword: () => 'secret',
+    getViteSupabaseUrl: () => 'https://example.supabase.co',
+    getViteSupabaseAnonKey: () => 'anon',
+  },
+  getViteAppPassword: () => 'secret',
+  getViteSupabaseUrl: () => 'https://example.supabase.co',
+  getViteSupabaseAnonKey: () => 'anon',
+}))
 
 /**
  * Render a Vue component using Vue Test Utils with proper router and global setup.
@@ -18,9 +30,6 @@ export async function renderComponent(file) {
     },
     configurable: true
   })
-
-  // Set up environment variables
-  process.env.VITE_APP_PASSWORD = 'secret'
 
   const component = (await import(`../../${file}`)).default
   
@@ -74,9 +83,7 @@ export async function resolveRoute(pathName, authenticated = false) {
     configurable: true
   })
   
-  process.env.VITE_APP_PASSWORD = 'secret'
-
-  const routes = rawRoutes.map((r) => ({ 
+  const routes = rawRoutes.map((r) => ({
     ...r, 
     component: { template: '<div>Test Route</div>' }
   }))

--- a/tests/testUtils.js
+++ b/tests/testUtils.js
@@ -1,7 +1,8 @@
+import { env } from '../src/configuration/env.js'
+
 export const PASSWORD = 'secret'
 
-export function setupTestEnvironment(t) {
-  const originalEnv = { ...process.env }
+export function setupTestEnvironment(t, { password = PASSWORD } = {}) {
   const originalSessionStorage = global.sessionStorage
   const store = {}
 
@@ -15,10 +16,10 @@ export function setupTestEnvironment(t) {
     },
   }
 
-  process.env = { ...process.env, VITE_APP_PASSWORD: PASSWORD }
+  const passwordMock = t.mock.method(env, 'getViteAppPassword', () => password)
 
   t.after(() => {
     global.sessionStorage = originalSessionStorage
-    process.env = originalEnv
+    passwordMock.mock.restore()
   })
 }


### PR DESCRIPTION
## Summary
- add `src/configuration/env.js` exposing getters for password and Supabase variables
- use env getters in authentication composable and Supabase client
- mock env getters in tests instead of touching `process.env`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896596e26688323baf13aac4b7ac723