### PR TITLE
Add header and footer component tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "fix": "npm run lint:fix && npm run format",
-    "test:components": "node --test --experimental-test-coverage tests/components/**/*.js",
+    "test:components": "vitest run --dir tests/components",
     "test:composables": "node --test --experimental-test-coverage tests/composables/**/*.js",
     "test:router": "node --test --experimental-test-coverage tests/router/**/*.js",
     "test:pages": "vitest run --dir tests/pages",

--- a/tests/components/layout/footer/AppFooter.test.js
+++ b/tests/components/layout/footer/AppFooter.test.js
@@ -1,0 +1,11 @@
+import { test, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import AppFooter from '@/components/layout/footer/AppFooter.vue'
+
+test('AppFooter always renders copyright line and link', () => {
+  const wrapper = mount(AppFooter)
+  expect(wrapper.text()).toContain('© Memento Mori')
+  const link = wrapper.get('a')
+  expect(link.attributes('href')).toBe('https://github.com/GDUngureanu')
+  expect(link.text()).toBe('G. D. Ungureanu')
+})

--- a/tests/components/layout/header/AppHeader.test.js
+++ b/tests/components/layout/header/AppHeader.test.js
@@ -1,0 +1,33 @@
+import { test, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createRouter, createMemoryHistory } from 'vue-router'
+import AppHeader from '@/components/layout/header/AppHeader.vue'
+
+async function mountHeader(path) {
+  const router = createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      { path: '/', component: { template: '<div />' } },
+      { path: '/about', component: { template: '<div />' } },
+    ],
+  })
+  await router.push(path)
+  await router.isReady()
+  return mount(AppHeader, {
+    global: {
+      plugins: [router],
+    },
+  })
+}
+
+test('AppHeader renders on home route with expected text', async () => {
+  const wrapper = await mountHeader('/')
+  expect(wrapper.find('h1').text()).toBe('Memento Mori')
+  expect(wrapper.text()).toContain('As a Man among Men')
+})
+
+test('AppHeader does not render on non-home routes', async () => {
+  const wrapper = await mountHeader('/about')
+  expect(wrapper.find('h1').exists()).toBe(false)
+  expect(wrapper.html()).toBe('<!--v-if-->')
+})

--- a/tests/components/layout/navigation/AppNavigation.test.js
+++ b/tests/components/layout/navigation/AppNavigation.test.js
@@ -1,5 +1,5 @@
-import test from 'node:test'
-import assert from 'node:assert/strict'
+import { test, expect } from 'vitest'
+
 test('navbar collapse hides on small screens after link click', () => {
   const originalWindow = global.window
   global.window = { innerWidth: 500 }
@@ -21,7 +21,7 @@ test('navbar collapse hides on small screens after link click', () => {
   navigationLinkElement.addEventListener('click', closeMenu)
   navigationLinkElement.dispatchEvent(new Event('click'))
 
-  assert.equal(hideFunctionCalled, true)
+  expect(hideFunctionCalled).toBe(true)
   global.window = originalWindow
 })
 
@@ -66,9 +66,9 @@ test('prefetch only triggers after delay and cancels on quick leave', async () =
   navigationLinkElement.dispatchEvent(new Event('mouseover'))
   setTimeout(() => navigationLinkElement.dispatchEvent(new Event('mouseleave')), 100)
   await new Promise((r) => setTimeout(r, 200))
-  assert.equal(fetched, false)
+  expect(fetched).toBe(false)
 
   navigationLinkElement.dispatchEvent(new Event('mouseover'))
   await new Promise((r) => setTimeout(r, 200))
-  assert.equal(fetched, true)
+  expect(fetched).toBe(true)
 })

--- a/tests/components/shared/templates/actions/utils.test.js
+++ b/tests/components/shared/templates/actions/utils.test.js
@@ -1,5 +1,4 @@
-import test from 'node:test'
-import assert from 'node:assert/strict'
+import { test, expect } from 'vitest'
 import {
   getPriorityText,
   getPriorityClass,
@@ -7,13 +6,13 @@ import {
 } from '../../../../../src/components/shared/templates/actions/utils.js'
 
 test('getPriorityText returns correct labels', () => {
-  assert.equal(getPriorityText(PRIORITY_LEVELS.LOW), 'Low')
-  assert.equal(getPriorityText(PRIORITY_LEVELS.MEDIUM), 'Medium')
-  assert.equal(getPriorityText(PRIORITY_LEVELS.HIGH), 'High')
+  expect(getPriorityText(PRIORITY_LEVELS.LOW)).toBe('Low')
+  expect(getPriorityText(PRIORITY_LEVELS.MEDIUM)).toBe('Medium')
+  expect(getPriorityText(PRIORITY_LEVELS.HIGH)).toBe('High')
 })
 
 test('getPriorityClass returns correct classes', () => {
-  assert.equal(getPriorityClass(PRIORITY_LEVELS.LOW), 'text-secondary')
-  assert.equal(getPriorityClass(PRIORITY_LEVELS.MEDIUM), 'text-warning')
-  assert.equal(getPriorityClass(PRIORITY_LEVELS.HIGH), 'text-danger')
+  expect(getPriorityClass(PRIORITY_LEVELS.LOW)).toBe('text-secondary')
+  expect(getPriorityClass(PRIORITY_LEVELS.MEDIUM)).toBe('text-warning')
+  expect(getPriorityClass(PRIORITY_LEVELS.HIGH)).toBe('text-danger')
 })


### PR DESCRIPTION
## Summary
- test AppHeader rendering only on `/` and includes key text
- test AppFooter always displaying copyright line and author link
- convert component tests to Vitest and update script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896602cddc483239f97136b274fcc11