### PR TITLE
feat: add 404 not found route

### DIFF
--- a/src/configuration/router.js
+++ b/src/configuration/router.js
@@ -30,3 +30,5 @@ export function createAppRouter(history = createWebHashHistory(), routesConfig =
 
   return router
 }
+
+export { routes }

--- a/src/configuration/routes.js
+++ b/src/configuration/routes.js
@@ -33,6 +33,8 @@ const Destinations = () => import('@/pages/adventure/destinations/Destinations.v
 // Practice Components
 const Practice = () => import('@/pages/practice/Practice.vue')
 const Routines = () => import('@/pages/practice/routines/Routines.vue')
+// Not Found
+const NotFound = () => import('@/pages/NotFound.vue')
 
 export default [
   { path: '/', component: Home, meta: { label: 'Home', group: null, requiresAuth: false } },
@@ -52,4 +54,5 @@ export default [
   { path: '/adventure/destinations', component: Destinations, meta: { label: 'Destinations', group: 'adventure', requiresAuth: false } },
   { path: '/practice', component: Practice, meta: { label: 'Overview', group: 'practice', requiresAuth: true } },
   { path: '/practice/routines', component: Routines, meta: { label: 'Routines', group: 'practice', requiresAuth: true } },
+  { path: '/:pathMatch(.*)*', component: NotFound },
 ]

--- a/src/pages/NotFound.vue
+++ b/src/pages/NotFound.vue
@@ -1,0 +1,10 @@
+<script setup>
+  defineOptions({
+    name: 'NotFoundPage',
+  })
+</script>
+
+<template>
+  <p>404 - Page Not Found</p>
+</template>
+

--- a/tests/router/notFound.test.js
+++ b/tests/router/notFound.test.js
@@ -1,0 +1,17 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { createMemoryHistory } from 'vue-router'
+import { routes, createAppRouter } from '../../src/configuration/router.js'
+import { setupTestEnvironment } from '../testUtils.js'
+
+test('unknown paths render the 404 component', async (t) => {
+  setupTestEnvironment(t)
+  const notFoundStub = {}
+  const stubbedRoutes = routes.map((route) =>
+    route.path === '/:pathMatch(.*)*' ? { ...route, component: notFoundStub } : { ...route, component: {} }
+  )
+  const router = createAppRouter(createMemoryHistory(), stubbedRoutes)
+  await router.push('/does-not-exist')
+  assert.equal(router.currentRoute.value.matched[0].components.default, notFoundStub)
+})
+


### PR DESCRIPTION
## Summary
- add NotFound page component
- route all unknown paths to NotFound and expose routes from router
- test 404 routing behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689665846f8c832380bb5b43b22757f9