### PR TITLE
chore: refine inline comments

### DIFF
--- a/src/components/shared/templates/actions/utils.js
+++ b/src/components/shared/templates/actions/utils.js
@@ -1,9 +1,16 @@
+/**
+ * Discrete priority levels used by actions.
+ * @readonly
+ */
 export const PRIORITY_LEVELS = {
   LOW: 0,
   MEDIUM: 1,
   HIGH: 2,
 }
 
+/**
+ * Display configuration for each priority level.
+ */
 export const PRIORITY_CONFIG = {
   [PRIORITY_LEVELS.LOW]: {
     text: 'Low',
@@ -22,8 +29,23 @@ export const PRIORITY_CONFIG = {
   },
 }
 
+/**
+ * Format an ISO date string for display using the user's locale.
+ * @param {string|number|Date} dateString
+ * @returns {string}
+ */
 export const formatDate = (dateString) => new Date(dateString).toLocaleDateString()
 
+/**
+ * Resolve a human-readable label for the given priority.
+ * @param {number} priority
+ * @returns {string}
+ */
 export const getPriorityText = (priority) => PRIORITY_CONFIG[priority]?.text || 'Low'
 
+/**
+ * Resolve the CSS class associated with the given priority.
+ * @param {number} priority
+ * @returns {string}
+ */
 export const getPriorityClass = (priority) => PRIORITY_CONFIG[priority]?.class || 'text-secondary'

--- a/src/configuration/authentication/authenticationEvents.js
+++ b/src/configuration/authentication/authenticationEvents.js
@@ -1,3 +1,13 @@
+/**
+ * EventTarget used to dispatch and listen for authentication-related events,
+ * such as {@link AUTH_REQUIRED_EVENT}.
+ * @type {EventTarget}
+ */
 export const authenticationEvents = new EventTarget()
 
+/**
+ * Event name emitted on {@link authenticationEvents} when a route requires
+ * authentication.
+ * @type {string}
+ */
 export const AUTH_REQUIRED_EVENT = 'authentication-required'

--- a/src/configuration/authentication/useAuthentication.js
+++ b/src/configuration/authentication/useAuthentication.js
@@ -2,7 +2,6 @@ import { ref, computed, watchEffect } from 'vue'
 import routes from '../routes.js'
 import { env } from '../env.js'
 
-// Reactive authentication state
 const isAuthenticated = ref(false)
 
 // Build a lookup of route metadata for quick access checks
@@ -11,7 +10,7 @@ const routeMeta = routes.reduce((metaByPath, route) => {
   return metaByPath
 }, {})
 
-// Check sessionStorage on composable creation and watch for changes
+// Check sessionStorage on initialization
 if (typeof sessionStorage !== 'undefined') {
   const storedAuthentication = sessionStorage.getItem('memento-mori-authentication')
   if (storedAuthentication === 'true') {
@@ -86,7 +85,7 @@ export function useAuthentication() {
     return isRoutePublic(path) || isAuthenticated.value
   }
 
-  // Build navigation items from route metadata
+  // Build primary navigation menu, hiding restricted routes for unauthenticated users
   const navigationItems = computed(() => {
     return routes
       .filter((route) => !route.meta?.group)

--- a/src/main.js
+++ b/src/main.js
@@ -1,14 +1,7 @@
-// Vue imports
 import { createApp } from 'vue'
-
-// Third-party library imports
 import { Popover } from 'bootstrap'
-
-// Local component imports
 import App from '@/App.vue'
 import { createAppRouter } from '@/configuration/router.js'
-
-// Styles
 import '@/scss/styles.scss'
 import 'bootstrap-icons/font/bootstrap-icons.css'
 


### PR DESCRIPTION
## Summary
- remove redundant import grouping comments in main.js
- clarify authentication state handling and navigation filtering comments
- add documentation for priority helpers and auth event constants

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68966d3179a88323b3130898dde9adde