### PR TITLE
test: verify navigation responds to auth state

### DIFF
--- a/tests/components/layout/navigation/AppNavigation.auth.test.js
+++ b/tests/components/layout/navigation/AppNavigation.auth.test.js
@@ -1,0 +1,73 @@
+import { mount } from '@vue/test-utils'
+import { test, expect, vi } from 'vitest'
+import { ref, computed, nextTick } from 'vue'
+import AppNavigation from '@/components/layout/navigation/AppNavigation.vue'
+
+// Mock router to observe prefetch calls
+const componentSpy = vi.fn()
+const mockRouter = {
+  resolve: vi.fn(() => ({
+    matched: [
+      {
+        components: { default: componentSpy },
+      },
+    ],
+  })),
+}
+vi.mock('vue-router', () => ({
+  useRouter: () => mockRouter,
+}))
+
+// Mock authentication composable with reactive auth state
+const isAuthenticated = ref(false)
+const navigationItems = computed(() =>
+  isAuthenticated.value
+    ? [
+        { path: '/public', label: 'Public' },
+        { path: '/private', label: 'Private' },
+      ]
+    : [{ path: '/public', label: 'Public' }]
+)
+const logoutMock = vi.fn()
+vi.mock('@/configuration/authentication/useAuthentication.js', () => ({
+  useAuthentication: () => ({
+    isAuthenticated: computed(() => isAuthenticated.value),
+    navigationItems,
+    dropdownSections: computed(() => ({})),
+    logout: logoutMock,
+  }),
+}))
+
+test('menu items react to authentication state and prefetch on hover', async () => {
+  vi.useFakeTimers()
+
+  const wrapper = mount(AppNavigation, {
+    global: {
+      stubs: {
+        RouterLink: { template: '<a><slot /></a>' },
+      },
+    },
+  })
+
+  // unauthenticated state
+  expect(wrapper.text()).toContain('Public')
+  expect(wrapper.text()).not.toContain('Private')
+  expect(wrapper.text()).toContain('Login')
+  expect(wrapper.text()).not.toContain('Logout')
+
+  // prefetch logic on hover
+  await wrapper.find('a').trigger('mouseover')
+  vi.runAllTimers()
+  expect(mockRouter.resolve).toHaveBeenCalledWith('/public')
+  expect(componentSpy).toHaveBeenCalled()
+
+  // authenticated state
+  isAuthenticated.value = true
+  await nextTick()
+
+  expect(wrapper.text()).toContain('Private')
+  expect(wrapper.text()).toContain('Logout')
+  expect(wrapper.text()).not.toContain('Login')
+
+  vi.useRealTimers()
+})


### PR DESCRIPTION
## Summary
- add authentication-aware spec for AppNavigation
- assert menu items and auth controls update when logging in/out
- confirm prefetch logic triggers on hover

## Testing
- `npm run test:components`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689670d3a23c83238541aba98dde071b