### PR TITLE
test: add Article template render test

### DIFF
--- a/tests/components/shared/templates/Article.test.js
+++ b/tests/components/shared/templates/Article.test.js
@@ -1,0 +1,18 @@
+import { test, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import Article from '@/components/shared/templates/Article.vue'
+
+test('renders heading, meta text, and slot content', () => {
+  const title = 'Sample Title'
+  const meta = 'Sample Meta'
+  const slotContent = '<p class="slot">Slot Content</p>'
+
+  const wrapper = mount(Article, {
+    props: { title, meta },
+    slots: { default: slotContent },
+  })
+
+  expect(wrapper.get('h3').text()).toBe(title)
+  expect(wrapper.get('.blog-post-meta em').text()).toBe(meta)
+  expect(wrapper.get('.slot').text()).toBe('Slot Content')
+})


### PR DESCRIPTION
## Summary
- add Article template unit test verifying heading, metadata, and slot rendering

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689672611dc483239d92b9c2c76ff7e7