### PR TITLE
test: cover anime and movies pages

### DIFF
--- a/tests/pages/entertainment/anime.test.js
+++ b/tests/pages/entertainment/anime.test.js
@@ -1,0 +1,25 @@
+import { test, expect } from 'vitest'
+import { renderComponent } from '../pageTestUtils.js'
+import animeList from '../../../src/pages/entertainment/data.json'
+
+const file = 'src/pages/entertainment/Anime.vue'
+
+test('ArticleTemplate renders with correct title and meta', async () => {
+  const wrapper = await renderComponent(file)
+  const article = wrapper.find('article-template-stub')
+  expect(article.exists()).toBe(true)
+  expect(article.attributes('title')).toBe('Anime List')
+  expect(article.attributes('meta')).toBe('May 13, 2025 by G. D. Ungureanu')
+})
+
+test('ActionsTemplate is present', async () => {
+  const wrapper = await renderComponent(file)
+  expect(wrapper.find('actions-template-stub').exists()).toBe(true)
+})
+
+test('renders table rows from data.json', async () => {
+  const wrapper = await renderComponent(file)
+  const rows = wrapper.findAll('tbody tr')
+  expect(rows.length).toBe(animeList.length)
+})
+

--- a/tests/pages/entertainment/movies.test.js
+++ b/tests/pages/entertainment/movies.test.js
@@ -1,0 +1,18 @@
+import { test, expect } from 'vitest'
+import { renderComponent } from '../pageTestUtils.js'
+
+const file = 'src/pages/entertainment/Movies.vue'
+
+test('ArticleTemplate renders with correct title and meta', async () => {
+  const wrapper = await renderComponent(file)
+  const article = wrapper.find('article-template-stub')
+  expect(article.exists()).toBe(true)
+  expect(article.attributes('title')).toBe('Movies Actions')
+  expect(article.attributes('meta')).toBe('July 31, 2025 by G. D. Ungureanu')
+})
+
+test('ActionsTemplate is present', async () => {
+  const wrapper = await renderComponent(file)
+  expect(wrapper.find('actions-template-stub').exists()).toBe(true)
+})
+


### PR DESCRIPTION
## Summary
- ensure Anime page renders ActionsTemplate with default stubs
- expose ArticleTemplate slots in page test renderer and simplify entertainment tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68967c11979c83239c50f3e57ef07270