### PR TITLE
test: add supabase configuration tests

### DIFF
--- a/tests/configuration/supabase.test.js
+++ b/tests/configuration/supabase.test.js
@@ -1,0 +1,65 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import vm from 'node:vm'
+
+async function loadSupabaseModule({ url, key }) {
+  const code = await readFile(new URL('../../src/configuration/supabase.js', import.meta.url), 'utf8')
+  const transformed = code
+    .replace("import { createClient } from '@supabase/supabase-js'\n", '')
+    .replace("import { env } from './env.js'\n", '')
+    .replace('export const supabase', 'const supabase')
+  const calls = []
+  const createClientMock = (...args) => {
+    calls.push(args)
+    return {}
+  }
+  const envMock = {
+    getViteSupabaseUrl: () => url,
+    getViteSupabaseAnonKey: () => key,
+  }
+  try {
+    vm.runInNewContext(transformed, { createClient: createClientMock, env: envMock })
+    return { calls }
+  } catch (err) {
+    err.calls = calls
+    throw err
+  }
+}
+
+test('missing URL and key prioritizes missing URL error', async () => {
+  await assert.rejects(
+    loadSupabaseModule({ url: undefined, key: undefined }),
+    /Missing VITE_SUPABASE_URL/,
+  )
+})
+
+test('missing URL throws an error', async () => {
+  await assert.rejects(
+    loadSupabaseModule({ url: undefined, key: 'anon' }),
+    /Missing VITE_SUPABASE_URL/
+  )
+})
+
+test('missing anon key throws an error', async () => {
+  await assert.rejects(
+    loadSupabaseModule({ url: 'https://example.supabase.co', key: undefined }),
+    /Missing VITE_SUPABASE_ANON_KEY/
+  )
+})
+
+test('createClient is called with expected options when credentials provided', async () => {
+  const url = 'https://example.supabase.co'
+  const key = 'anon'
+  const { calls } = await loadSupabaseModule({ url, key })
+  assert.equal(calls.length, 1)
+  assert.equal(calls[0][0], url)
+  assert.equal(calls[0][1], key)
+  const options = calls[0][2]
+  assert.equal(options.auth.persistSession, true)
+  assert.equal(options.auth.autoRefreshToken, true)
+  assert.equal(options.auth.detectSessionInUrl, true)
+  assert.equal(options.auth.storageKey, 'small-steps-key')
+  assert.equal(options.auth.storage, undefined)
+  assert.equal(options.global.headers['X-Client-Info'], 'small-steps-client')
+})


### PR DESCRIPTION
## Summary
- add test verifying Supabase configuration errors when credentials are missing
- ensure createClient called with expected auth and header options
- verify missing URL and key defaults to URL missing error

## Testing
- `node --test tests/configuration/supabase.test.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68967c0cb0d48323ae96af6c3722c4b9