### PR TITLE
feat: lazy load adventure map with intersection observer

### DIFF
--- a/src/pages/adventure/destinations/Destinations.vue
+++ b/src/pages/adventure/destinations/Destinations.vue
@@ -267,10 +267,26 @@
     }
   }
 
-  onMounted(async () => {
-    const { default: L } = await import('leaflet')
-    await import('leaflet/dist/leaflet.css')
-    await initializeMap(L)
+  onMounted(() => {
+    const loadMap = async () => {
+      const { default: L } = await import('leaflet')
+      await import('leaflet/dist/leaflet.css')
+      await initializeMap(L)
+    }
+
+    if (typeof window !== 'undefined' && 'IntersectionObserver' in window) {
+      const observer = new IntersectionObserver(async (entries, obs) => {
+        if (entries.some((entry) => entry.isIntersecting)) {
+          obs.disconnect()
+          await loadMap()
+        }
+      })
+      if (mapElement.value) {
+        observer.observe(mapElement.value)
+      }
+    } else {
+      loadMap()
+    }
   })
 </script>
 
@@ -506,7 +522,7 @@
   <ArticleTemplate title="Destinations Map" meta="August 4, 2025 by G. D. Ungureanu">
     <div class="mb-4">
       <!-- Loading State -->
-      <div v-if="isLoading" class="map-container mb-4 d-flex align-items-center justify-content-center">
+      <div v-if="isLoading" ref="mapElement" class="map-container mb-4 d-flex align-items-center justify-content-center">
         <div class="text-center">
           <div class="spinner-border text-primary mb-2" role="status" aria-live="polite" aria-label="Loading map data">
             <span class="visually-hidden">Loading...</span>
@@ -516,7 +532,7 @@
       </div>
 
       <!-- Error State -->
-      <div v-else-if="loadError" class="map-container mb-4 d-flex align-items-center justify-content-center">
+      <div v-else-if="loadError" ref="mapElement" class="map-container mb-4 d-flex align-items-center justify-content-center">
         <div class="text-center">
           <i class="bi bi-exclamation-triangle text-warning fs-1 mb-2"></i>
           <p class="text-danger">Failed to load map data</p>

--- a/tests/pages/adventure/destinations/destinations.test.js
+++ b/tests/pages/adventure/destinations/destinations.test.js
@@ -4,22 +4,30 @@ import { renderComponent, resolveRoute } from '../../pageTestUtils.js'
 const file = 'src/pages/adventure/destinations/Destinations.vue'
 const path = '/adventure/destinations'
 
+// Expose mocks to tests for call count assertions
+let mapMock, tileLayerMock, geoJSONMock
+
 // Mock Leaflet imports since they're not available in test environment
-vi.mock('leaflet', () => ({
-  default: {
-    map: vi.fn(() => ({
-      setView: vi.fn(),
-      on: vi.fn(),
-      remove: vi.fn(),
-    })),
-    tileLayer: vi.fn(() => ({
-      addTo: vi.fn(),
-    })),
-    geoJSON: vi.fn(() => ({
-      addTo: vi.fn(),
-    })),
+vi.mock('leaflet', () => {
+  mapMock = vi.fn(() => ({
+    setView: vi.fn(),
+    on: vi.fn(),
+    remove: vi.fn(),
+  }))
+  tileLayerMock = vi.fn(() => ({
+    addTo: vi.fn(),
+  }))
+  geoJSONMock = vi.fn(() => ({
+    addTo: vi.fn(),
+  }))
+  return {
+    default: {
+      map: mapMock,
+      tileLayer: tileLayerMock,
+      geoJSON: geoJSONMock,
+    },
   }
-}))
+})
 
 vi.mock('leaflet/dist/leaflet.css', () => ({}))
 
@@ -32,4 +40,81 @@ test('Destinations page renders without errors', async () => {
 test('Destinations route resolves correctly', async () => {
   const resolved = await resolveRoute(path)
   expect(resolved).toBe(path)
+})
+
+test('map loads only when observed and observer disconnects', async () => {
+  // Ensure previous tests don't affect call counts
+  mapMock.mockClear()
+
+  const originalIO = global.IntersectionObserver
+  const originalFetch = global.fetch
+
+  let trigger
+  let observeMock
+  let disconnectMock
+  class MockIO {
+    constructor(cb) {
+      this.cb = cb
+      this.disconnected = false
+      observeMock = vi.fn()
+      disconnectMock = vi.fn(() => {
+        this.disconnected = true
+      })
+      this.observe = observeMock
+      this.disconnect = disconnectMock
+      trigger = (entries) => {
+        if (!this.disconnected) {
+          this.cb(entries, this)
+        }
+      }
+    }
+  }
+
+  Object.defineProperty(global, 'IntersectionObserver', {
+    value: MockIO,
+    configurable: true,
+    writable: true,
+  })
+
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve({ type: 'FeatureCollection', features: [] }),
+  })
+
+  try {
+    const wrapper = await renderComponent(file)
+
+    expect(mapMock).not.toHaveBeenCalled()
+    expect(wrapper.vm.isLoading).toBe(true)
+    expect(observeMock).toHaveBeenCalledTimes(1)
+
+    // Simulate map entering viewport
+    trigger([{ isIntersecting: true }])
+    await new Promise((r) => setTimeout(r, 0))
+
+    expect(mapMock).toHaveBeenCalledTimes(1)
+    // Observer should disconnect after loading
+    expect(disconnectMock).toHaveBeenCalledTimes(1)
+    expect(wrapper.vm.isLoading).toBe(false)
+    expect(wrapper.find('.spinner-border').exists()).toBe(false)
+
+    // Subsequent intersections should do nothing
+    trigger([{ isIntersecting: true }])
+    await new Promise((r) => setTimeout(r, 0))
+    expect(mapMock).toHaveBeenCalledTimes(1)
+    expect(disconnectMock).toHaveBeenCalledTimes(1)
+    expect(wrapper.find('.spinner-border').exists()).toBe(false)
+  } finally {
+    // Restore globals
+    if (originalIO === undefined) {
+      delete global.IntersectionObserver
+    } else {
+      Object.defineProperty(global, 'IntersectionObserver', {
+        value: originalIO,
+        configurable: true,
+        writable: true,
+      })
+    }
+    global.fetch = originalFetch
+  }
 })


### PR DESCRIPTION
## Summary
- defer Leaflet map setup until the map scrolls into view using IntersectionObserver
- import Leaflet and styles inside the observer callback and disconnect after loading
- always reference the map container so observation works during loading and error states
- add test to ensure map initialization only occurs after intersection and observer disconnects

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68974a4e54708323b633c5fdbfd0d741