### PR TITLE
Add navigation prefetch cleanup

### DIFF
--- a/src/components/layout/navigation/AppNavigation.vue
+++ b/src/components/layout/navigation/AppNavigation.vue
@@ -1,5 +1,5 @@
 <script setup>
-  import { ref, onMounted } from 'vue'
+  import { ref, onMounted, onBeforeUnmount } from 'vue'
   import { useRouter } from 'vue-router'
   import { Collapse } from 'bootstrap'
   import { useAuthentication } from '@/configuration/authentication/useAuthentication.js'
@@ -49,6 +49,11 @@
     if (navbarCollapse.value) {
       bootstrapCollapse = new Collapse(navbarCollapse.value, { toggle: false })
     }
+  })
+
+  onBeforeUnmount(() => {
+    clearTimeout(prefetchTimer)
+    cancelPrefetch()
   })
 
   const closeMenu = () => {

--- a/tests/components/layout/navigation/AppNavigation.auth.test.js
+++ b/tests/components/layout/navigation/AppNavigation.auth.test.js
@@ -71,3 +71,35 @@ test('menu items react to authentication state and prefetch on hover', async () 
 
   vi.useRealTimers()
 })
+
+test('clears prefetch timer and invokes cancelPrefetch on unmount', () => {
+  vi.useFakeTimers()
+
+  const wrapper = mount(AppNavigation, {
+    global: {
+      stubs: {
+        RouterLink: { template: '<a><slot /></a>' },
+      },
+    },
+  })
+
+  const clearTimeoutSpy = vi.spyOn(global, 'clearTimeout')
+
+  // start a prefetch timer
+  wrapper.vm.prefetch('/public')
+
+  // reset spies to track unmount cleanup
+  clearTimeoutSpy.mockClear()
+  componentSpy.mockClear()
+
+  wrapper.unmount()
+
+  // clearTimeout should run once directly and once via cancelPrefetch
+  expect(clearTimeoutSpy).toHaveBeenCalledTimes(2)
+
+  // ensure the scheduled prefetch never runs
+  vi.runAllTimers()
+  expect(componentSpy).not.toHaveBeenCalled()
+
+  vi.useRealTimers()
+})


### PR DESCRIPTION
## Summary
- clear pending navigation prefetch timeout on component unmount
- add unit test to verify cleanup

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68974a73191c8323aa322742261725e9