### PR TITLE
Add Escape key handling to AccessModal

### DIFF
--- a/src/configuration/authentication/components/AccessModal.vue
+++ b/src/configuration/authentication/components/AccessModal.vue
@@ -1,5 +1,5 @@
 <script setup>
-  import { ref, nextTick, watch, computed } from 'vue'
+  import { ref, nextTick, watch, computed, onMounted, onBeforeUnmount } from 'vue'
   import { useAuthentication } from '../useAuthentication.js'
 
   /**
@@ -26,6 +26,7 @@
   const error = ref('')
   const isSubmitting = ref(false)
   const passwordInput = ref(null)
+  const modalRef = ref(null)
 
   // Computed property for form validation
   const isValidPassword = computed(() => password.value.trim().length > 0)
@@ -78,13 +79,41 @@
     emit('hide')
   }
 
+  const handleEscape = (event) => {
+    if (event.key !== 'Escape' || !props.show) return
+
+    const tag = event.target?.closest('input,textarea,select')?.tagName
+    if (tag) return
+
+    const modals = Array.from(document.querySelectorAll('.modal.show'))
+    const topModal = modals[modals.length - 1]
+    if (modalRef.value === topModal) {
+      handleCancel()
+    }
+  }
+
+  onMounted(() => {
+    window.addEventListener('keyup', handleEscape)
+  })
+
+  onBeforeUnmount(() => {
+    window.removeEventListener('keyup', handleEscape)
+  })
+
   defineOptions({
     name: 'AccessModal',
   })
 </script>
 
 <template>
-  <div class="modal fade" :class="{ show: show }" :style="{ display: show ? 'block' : 'none' }" tabindex="-1" @click.self="handleCancel">
+  <div
+    ref="modalRef"
+    class="modal fade"
+    :class="{ show: show }"
+    :style="{ display: show ? 'block' : 'none' }"
+    tabindex="-1"
+    @click.self="handleCancel"
+  >
     <div class="modal-dialog modal-dialog-centered">
       <div class="modal-content">
         <div class="modal-header">

--- a/tests/configuration/authentication/AccessModal.test.js
+++ b/tests/configuration/authentication/AccessModal.test.js
@@ -67,5 +67,50 @@ describe('AccessModal', () => {
     expect(wrapper.emitted('hide')).toHaveLength(2)
     wrapper.unmount()
   })
+
+  it('AccessModal emits hide when Escape key is pressed', async () => {
+    const wrapper = mountModal()
+
+    window.dispatchEvent(new KeyboardEvent('keyup', { key: 'Escape' }))
+    await nextTick()
+
+    expect(wrapper.emitted('hide')).toHaveLength(1)
+    wrapper.unmount()
+  })
+
+  it('does not emit hide when Escape is pressed while hidden', async () => {
+    const wrapper = mountModal({ show: false })
+
+    window.dispatchEvent(new KeyboardEvent('keyup', { key: 'Escape' }))
+    await nextTick()
+
+    expect(wrapper.emitted('hide')).toBeFalsy()
+    wrapper.unmount()
+  })
+
+  it('does not emit hide when Escape originates from an input', async () => {
+    const wrapper = mountModal()
+    const input = wrapper.find('#authPassword')
+    input.element.focus()
+    input.element.dispatchEvent(new KeyboardEvent('keyup', { key: 'Escape', bubbles: true }))
+    await nextTick()
+
+    expect(wrapper.emitted('hide')).toBeFalsy()
+    wrapper.unmount()
+  })
+
+  it('only the topmost modal emits hide on Escape', async () => {
+    const first = mountModal()
+    const second = mountModal()
+
+    window.dispatchEvent(new KeyboardEvent('keyup', { key: 'Escape' }))
+    await nextTick()
+
+    expect(first.emitted('hide')).toBeFalsy()
+    expect(second.emitted('hide')).toHaveLength(1)
+
+    first.unmount()
+    second.unmount()
+  })
 })
 


### PR DESCRIPTION
## Summary
- guard AccessModal escape handler so only visible, topmost modals close and key events from inputs are ignored
- expand AccessModal tests for hidden, input-focused and stacked modal escape behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68974ab0d35083238b651a58868f6b7d