### PR TITLE
feat: add markdown article template

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "sass-loader": "^16.0.5",
     "vite": "^6.3.5",
     "vitest": "^3.2.4",
-    "vue-loader": "^17.4.2"
+    "vue-loader": "^17.4.2",
+    "vite-plugin-markdown": "^2.1.0"
   }
 }

--- a/src/components/shared/templates/Articles.vue
+++ b/src/components/shared/templates/Articles.vue
@@ -1,0 +1,81 @@
+<script setup>
+import { ref, defineAsyncComponent } from 'vue'
+
+  /**
+   * Article template that loads Markdown content.
+   *
+   * @prop {string} src path to the markdown file
+   * @prop {string} title heading text displayed above the content
+   * @prop {string} meta small subtitle or metadata string
+   * @prop {boolean} expanded whether the article is open by default (default: true)
+   */
+  const props = defineProps({
+    src: { type: String, required: true },
+    title: String,
+    meta: String,
+    expanded: {
+      type: Boolean,
+      default: true
+    }
+  })
+
+  const isExpanded = ref(props.expanded)
+
+  function toggleExpanded() {
+    isExpanded.value = !isExpanded.value
+  }
+
+  const MarkdownComponent = defineAsyncComponent(() => import(props.src))
+</script>
+
+<template>
+  <div class="row p-4 mb-4 rounded-3 border shadow-lg">
+    <article class="blog-post">
+      <div class="d-flex justify-content-between align-items-start cursor-pointer" @click="toggleExpanded">
+        <div>
+          <h3 class="display-6 link-body-emphasis mb-0">{{ title }}</h3>
+          <p class="blog-post-meta">
+            <em>{{ meta }}</em>
+          </p>
+        </div>
+        <button
+          class="btn btn-sm p-1 text-muted article-toggle"
+          :aria-label="isExpanded ? 'Collapse section' : 'Expand section'"
+        >
+          <i class="bi" :class="isExpanded ? 'bi-chevron-up' : 'bi-chevron-down'"></i>
+        </button>
+      </div>
+
+      <div class="article-content" :class="{ 'collapsed': !isExpanded }">
+        <component :is="MarkdownComponent" />
+      </div>
+    </article>
+  </div>
+</template>
+
+<style scoped>
+.cursor-pointer {
+  cursor: pointer;
+}
+
+.article-toggle {
+  border: none !important;
+  background: none !important;
+  transition: transform 0.2s ease;
+}
+
+.article-toggle:hover {
+  transform: scale(1.1);
+}
+
+.article-content {
+  overflow: hidden;
+  transition: max-height 0.3s ease, opacity 0.3s ease;
+  opacity: 1;
+}
+
+.article-content.collapsed {
+  max-height: 0;
+  opacity: 0;
+}
+</style>

--- a/src/content/sample.md
+++ b/src/content/sample.md
@@ -1,0 +1,3 @@
+# Sample Markdown
+
+This is a **markdown** file used for testing.

--- a/tests/components/shared/templates/Articles.test.js
+++ b/tests/components/shared/templates/Articles.test.js
@@ -1,0 +1,18 @@
+import { test, expect, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { defineComponent } from 'vue'
+import Articles from '@/components/shared/templates/Articles.vue'
+
+vi.mock('@/content/sample.md', () => ({
+  __esModule: true,
+  default: defineComponent({ template: '<div>Sample Markdown</div>' })
+}), { virtual: true })
+
+test('renders markdown content inside article container', async () => {
+  const wrapper = mount(Articles, {
+    props: { title: 'MD', meta: 'meta', src: '@/content/sample.md' }
+  })
+  await flushPromises()
+  await flushPromises()
+  expect(wrapper.html()).toContain('Sample Markdown')
+})

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,10 +1,14 @@
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
+import Markdown from 'vite-plugin-markdown'
 import path from 'node:path'
 
 export default defineConfig({
   base: '/small-steps/',
-  plugins: [vue()],
+  plugins: [
+    vue({ include: [/\.vue$/, /\.md$/] }),
+    Markdown({ mode: ['vue'] })
+  ],
   resolve: {
     alias: { '@': path.resolve(__dirname, 'src') }
   },


### PR DESCRIPTION
## Summary
- support rendering Markdown files via new Articles template
- enable vite-plugin-markdown in Vite config
- add vite-plugin-markdown dependency
- resolve dynamic Markdown imports via alias path

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c491740688323907de3dbd763060e