### PR TITLE
Use marked for article markdown rendering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "bootstrap": "^5.3.6",
         "bootstrap-icons": "^1.13.1",
         "leaflet": "^1.9.4",
+        "marked": "^12.0.2",
         "vue": "^3.5.14",
         "vue-router": "^4.5.1"
       },
@@ -29,7 +30,6 @@
         "sass": "^1.89.0",
         "sass-loader": "^16.0.5",
         "vite": "^6.3.5",
-        "vite-plugin-markdown": "^2.2.0",
         "vitest": "^3.2.4",
         "vue-loader": "^17.4.2"
       }
@@ -2823,75 +2823,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/dom-serializer": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
-      "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^2.0.1",
-        "domhandler": "^4.2.0",
-        "entities": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-      }
-    },
-    "node_modules/dom-serializer/node_modules/entities": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/domelementtype": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/domhandler": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
-      "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "domelementtype": "^2.2.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domhandler?sponsor=1"
-      }
-    },
-    "node_modules/domutils": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
-      "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "dom-serializer": "^1.0.1",
-        "domelementtype": "^2.2.0",
-        "domhandler": "^4.2.0"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domutils?sponsor=1"
-      }
-    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -3230,20 +3161,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/esquery": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
@@ -3527,40 +3444,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/front-matter": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/front-matter/-/front-matter-4.0.2.tgz",
-      "integrity": "sha512-I8ZuJ/qG92NWX8i5x1Y8qyj3vizhXS31OxjKDu3LKP+7/qBgfIKValiZIEwoVoJKUHlhWtYrktkxV1XsX+pPlg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "js-yaml": "^3.13.1"
-      }
-    },
-    "node_modules/front-matter/node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/front-matter/node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
     "node_modules/fs-extra": {
       "version": "11.3.1",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.1.tgz",
@@ -3750,36 +3633,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/htmlparser2": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
-      "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
-      "dev": true,
-      "funding": [
-        "https://github.com/fb55/htmlparser2?sponsor=1",
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^2.0.1",
-        "domhandler": "^4.0.0",
-        "domutils": "^2.5.2",
-        "entities": "^2.0.0"
-      }
-    },
-    "node_modules/htmlparser2/node_modules/entities": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/http-proxy-agent": {
@@ -4181,16 +4034,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/linkify-it": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
-      "integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "uc.micro": "^1.0.1"
-      }
-    },
     "node_modules/loader-runner": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
@@ -4273,40 +4116,6 @@
       "bin": {
         "semver": "bin/semver.js"
       }
-    },
-    "node_modules/markdown-it": {
-      "version": "12.3.2",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
-      "integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1",
-        "entities": "~2.1.0",
-        "linkify-it": "^3.0.1",
-        "mdurl": "^1.0.1",
-        "uc.micro": "^1.0.5"
-      },
-      "bin": {
-        "markdown-it": "bin/markdown-it.js"
-      }
-    },
-    "node_modules/markdown-it/node_modules/entities": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
-      "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/mdurl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
-      "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -5232,13 +5041,6 @@
         "source-map": "^0.6.0"
       }
     },
-    "node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -5678,13 +5480,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/uc.micro": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
-      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/undici-types": {
       "version": "7.10.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
@@ -5846,22 +5641,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/vite-plugin-markdown": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-markdown/-/vite-plugin-markdown-2.2.0.tgz",
-      "integrity": "sha512-eH2tXMZcx3EHb5okd+/0VIyoR8Gp9pGe24UXitOOcGkzObbJ1vl48aGOAbakoT88FBdzC8MXNkMfBIB9VK0Ndg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "domhandler": "^4.0.0",
-        "front-matter": "^4.0.0",
-        "htmlparser2": "^6.0.0",
-        "markdown-it": "^12.0.0"
-      },
-      "peerDependencies": {
-        "vite": ">= 2.0.0"
       }
     },
     "node_modules/vite/node_modules/fdir": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "bootstrap": "^5.3.6",
     "bootstrap-icons": "^1.13.1",
     "leaflet": "^1.9.4",
+    "marked": "^12.0.2",
     "vue": "^3.5.14",
     "vue-router": "^4.5.1"
   },
@@ -47,7 +48,6 @@
     "sass": "^1.89.0",
     "sass-loader": "^16.0.5",
     "vite": "^6.3.5",
-    "vite-plugin-markdown": "^2.2.0",
     "vitest": "^3.2.4",
     "vue-loader": "^17.4.2"
   }

--- a/src/components/shared/templates/Articles.vue
+++ b/src/components/shared/templates/Articles.vue
@@ -1,5 +1,6 @@
 <script setup>
-  import { ref, defineAsyncComponent } from 'vue'
+  import { ref, onMounted } from 'vue'
+  import { marked } from 'marked'
 
   /**
    * Article template that loads Markdown content.
@@ -20,12 +21,23 @@
   })
 
   const isExpanded = ref(props.expanded)
+  const content = ref('')
+
+  async function loadMarkdown() {
+    try {
+      const response = await fetch(props.src)
+      const text = await response.text()
+      content.value = marked.parse(text)
+    } catch {
+      content.value = '<p>Failed to load content.</p>'
+    }
+  }
 
   function toggleExpanded() {
     isExpanded.value = !isExpanded.value
   }
 
-  const MarkdownComponent = defineAsyncComponent(() => import(props.src))
+  onMounted(loadMarkdown)
 </script>
 
 <template>
@@ -43,9 +55,7 @@
         </button>
       </div>
 
-      <div class="article-content" :class="{ collapsed: !isExpanded }">
-        <component :is="MarkdownComponent" />
-      </div>
+      <div class="article-content" :class="{ collapsed: !isExpanded }" v-html="content" />
     </article>
   </div>
 </template>
@@ -78,3 +88,4 @@
     opacity: 0;
   }
 </style>
+

--- a/src/pages/pisicuta/laptops/Laptops.vue
+++ b/src/pages/pisicuta/laptops/Laptops.vue
@@ -1,11 +1,18 @@
 <script setup>
   import ArticleTemplate from '@/components/shared/templates/Articles.vue'
 
+  const markdownUrl = new URL('../../../content/sample.md', import.meta.url).href
+
   defineOptions({
     name: 'LaptopsTemplate',
   })
 </script>
 
 <template>
-  <!-- <ArticleTemplate title="Laptops List" meta="August 13, 2025 by G. D. Ungureanu" str='../../../content/sample.md'/> -->
+  <ArticleTemplate
+    :src="markdownUrl"
+    title="Laptops List"
+    meta="August 13, 2025 by G. D. Ungureanu"
+  />
 </template>
+

--- a/tests/components/shared/templates/Articles.test.js
+++ b/tests/components/shared/templates/Articles.test.js
@@ -1,22 +1,18 @@
 import { test, expect, vi } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
-import { defineComponent } from 'vue'
 import Articles from '@/components/shared/templates/Articles.vue'
 
-vi.mock(
-  '@/content/sample.md',
-  () => ({
-    __esModule: true,
-    default: defineComponent({ template: '<div>Sample Markdown</div>' }),
-  }),
-  { virtual: true }
-)
-
 test('renders markdown content inside article container', async () => {
+  global.fetch = vi.fn(() =>
+    Promise.resolve({ text: () => Promise.resolve('# Sample Markdown') })
+  )
+
   const wrapper = mount(Articles, {
-    props: { title: 'MD', meta: 'meta', src: '@/content/sample.md' },
+    props: { title: 'MD', meta: 'meta', src: '/sample.md' },
   })
+
   await flushPromises()
-  await flushPromises()
+
+  expect(global.fetch).toHaveBeenCalledWith('/sample.md')
   expect(wrapper.html()).toContain('Sample Markdown')
 })

--- a/tests/mocks/marked.js
+++ b/tests/mocks/marked.js
@@ -1,0 +1,3 @@
+export const marked = {
+  parse: (text) => `<p>${text}</p>`,
+}

--- a/tests/pages/pisicuta/laptops.test.js
+++ b/tests/pages/pisicuta/laptops.test.js
@@ -1,0 +1,16 @@
+import { test, expect } from 'vitest'
+import { renderComponent, resolveRoute } from '../pageTestUtils.js'
+
+const file = 'src/pages/pisicuta/laptops/Laptops.vue'
+const path = '/pisicuta/laptops'
+
+test('Laptops page renders without errors', async () => {
+  const wrapper = await renderComponent(file)
+  expect(wrapper.exists()).toBe(true)
+  expect(wrapper.html()).toContain('article-template-stub')
+})
+
+test('Laptops route resolves correctly', async () => {
+  const resolved = await resolveRoute(path)
+  expect(resolved).toBe(path)
+})

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,21 +1,23 @@
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
-import Markdown from 'vite-plugin-markdown'
 import path from 'node:path'
 
 export default defineConfig({
   plugins: [
     vue(),
-    Markdown({ mode: ['html', 'vue'] })
   ],
   test: {
     environment: 'jsdom',
     globals: true,
   },
   resolve: {
-    alias: { '@': path.resolve(__dirname, 'src') }
+    alias: {
+      '@': path.resolve(__dirname, 'src'),
+      marked: path.resolve(__dirname, 'tests/mocks/marked.js'),
+    },
   },
   define: {
     'process.env': process.env
   }
 })
+


### PR DESCRIPTION
## Summary
- render Markdown in Articles template by fetching source and parsing with marked
- remove vite-plugin-markdown and wire new Laptops page to use Articles template
- add tests for Articles and Laptops pages, aliasing marked in Vitest config

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c571f5a788323a379d2682b292c74