### PR TITLE
Fix laptops page tests by stubbing MDArticleTemplate and authenticating route

### DIFF
--- a/tests/pages/pageTestUtils.js
+++ b/tests/pages/pageTestUtils.js
@@ -62,6 +62,11 @@ export async function renderComponent(file, options = {}) {
             return h('article-template-stub', this.$slots.default ? this.$slots.default() : [])
           },
         },
+        MDArticleTemplate: {
+          render() {
+            return h('md-article-template-stub', this.$slots.default ? this.$slots.default() : [])
+          },
+        },
         ActionsTemplate: true,
         SuggestionsTemplate: true,
         ...((options.global && options.global.stubs) || {}),

--- a/tests/pages/pisicuta/laptops.test.js
+++ b/tests/pages/pisicuta/laptops.test.js
@@ -7,10 +7,10 @@ const path = '/pisicuta/laptops'
 test('Laptops page renders without errors', async () => {
   const wrapper = await renderComponent(file)
   expect(wrapper.exists()).toBe(true)
-  expect(wrapper.html()).toContain('article-template-stub')
+  expect(wrapper.html()).toContain('md-article-template-stub')
 })
 
 test('Laptops route resolves correctly', async () => {
-  const resolved = await resolveRoute(path)
+  const resolved = await resolveRoute(path, true)
   expect(resolved).toBe(path)
 })


### PR DESCRIPTION
## Summary
- stub `MDArticleTemplate` in page test utilities
- adjust laptops page tests to use the new stub and authenticate protected route

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c61f6dcf8832391b53eacf4002759