### PR TITLE
refactor: extract base article wrapper

### DIFF
--- a/docs/components/shared/templates.md
+++ b/docs/components/shared/templates.md
@@ -17,6 +17,7 @@ npm start
 
 ## Entry Points
 
-- `Article.vue` \u2013 basic article layout with title and metadata slots
-- `Actions.vue` \u2013 interactive task management template with Supabase integration
-- `Suggestions.vue` \u2013 renders a checklist from JSON data
+- `BaseArticle.vue` – shared article wrapper with header and toggle logic
+- `Article.vue` – basic article layout with title and metadata slots
+- `Actions.vue` – interactive task management template with Supabase integration
+- `Suggestions.vue` – renders a checklist from JSON data

--- a/src/components/shared/templates/Article.vue
+++ b/src/components/shared/templates/Article.vue
@@ -1,76 +1,18 @@
 <script setup>
-  import { ref } from 'vue'
+import BaseArticle from './BaseArticle.vue'
 
-  /**
-   * Basic article layout with a header and body slot.
-   *
-   * @prop {string} title heading text displayed above the content slot
-   * @prop {string} meta small subtitle or metadata string
-   * @prop {boolean} expanded whether the article is open by default (default: true)
-   */
-  const props = defineProps({
-    title: String,
-    meta: String,
-    expanded: {
-      type: Boolean,
-      default: true,
-    },
-  })
-
-  const isExpanded = ref(props.expanded)
-
-  function toggleExpanded() {
-    isExpanded.value = !isExpanded.value
-  }
+const props = defineProps({
+  title: String,
+  meta: String,
+  expanded: {
+    type: Boolean,
+    default: true,
+  },
+})
 </script>
 
 <template>
-  <div class="row p-4 mb-4 rounded-3 border shadow-lg">
-    <article class="blog-post">
-      <div class="d-flex justify-content-between align-items-start cursor-pointer" @click="toggleExpanded">
-        <div>
-          <h3 class="display-6 link-body-emphasis mb-0">{{ title }}</h3>
-          <p class="blog-post-meta">
-            <em>{{ meta }}</em>
-          </p>
-        </div>
-        <button class="btn btn-sm p-1 text-muted article-toggle" :aria-label="isExpanded ? 'Collapse section' : 'Expand section'">
-          <i class="bi" :class="isExpanded ? 'bi-chevron-up' : 'bi-chevron-down'"></i>
-        </button>
-      </div>
-
-      <div class="article-content" :class="{ collapsed: !isExpanded }">
-        <slot />
-      </div>
-    </article>
-  </div>
+  <BaseArticle v-bind="props">
+    <slot />
+  </BaseArticle>
 </template>
-
-<style scoped>
-  .cursor-pointer {
-    cursor: pointer;
-  }
-
-  .article-toggle {
-    border: none !important;
-    background: none !important;
-    transition: transform 0.2s ease;
-  }
-
-  .article-toggle:hover {
-    transform: scale(1.1);
-  }
-
-  .article-content {
-    overflow: hidden;
-    transition:
-      max-height 0.3s ease,
-      opacity 0.3s ease;
-    opacity: 1;
-  }
-
-  .article-content.collapsed {
-    max-height: 0;
-    opacity: 0;
-  }
-</style>

--- a/src/components/shared/templates/BaseArticle.vue
+++ b/src/components/shared/templates/BaseArticle.vue
@@ -1,0 +1,85 @@
+<script setup>
+import { ref, watch } from 'vue'
+
+/**
+ * Provides shared article layout with header and toggle logic.
+ *
+ * @prop {string} title heading text displayed above the content
+ * @prop {string} meta small subtitle or metadata string
+ * @prop {boolean} expanded whether the article is open by default (default: true)
+ */
+const props = defineProps({
+  title: String,
+  meta: String,
+  expanded: {
+    type: Boolean,
+    default: true,
+  },
+})
+
+const isExpanded = ref(props.expanded)
+
+// keep local state in sync with prop
+watch(
+  () => props.expanded,
+  value => {
+    isExpanded.value = value
+  }
+)
+
+function toggleExpanded() {
+  isExpanded.value = !isExpanded.value
+}
+</script>
+
+<template>
+  <div class="row p-4 mb-4 rounded-3 border shadow-lg">
+    <article class="blog-post">
+      <div class="d-flex justify-content-between align-items-start cursor-pointer" @click="toggleExpanded">
+        <div>
+          <h3 class="display-6 link-body-emphasis mb-0">{{ title }}</h3>
+          <p class="blog-post-meta"><em>{{ meta }}</em></p>
+        </div>
+        <button
+          class="btn btn-sm p-1 text-muted article-toggle"
+          :aria-label="isExpanded ? 'Collapse section' : 'Expand section'"
+        >
+          <i class="bi" :class="isExpanded ? 'bi-chevron-up' : 'bi-chevron-down'"></i>
+        </button>
+      </div>
+
+      <div class="article-content" :class="{ collapsed: !isExpanded }">
+        <slot />
+      </div>
+    </article>
+  </div>
+</template>
+
+<style scoped>
+.cursor-pointer {
+  cursor: pointer;
+}
+
+.article-toggle {
+  border: none !important;
+  background: none !important;
+  transition: transform 0.2s ease;
+}
+
+.article-toggle:hover {
+  transform: scale(1.1);
+}
+
+.article-content {
+  overflow: hidden;
+  transition:
+    max-height 0.3s ease,
+    opacity 0.3s ease;
+  opacity: 1;
+}
+
+.article-content.collapsed {
+  max-height: 0;
+  opacity: 0;
+}
+</style>

--- a/src/components/shared/templates/MarkdownArticle.vue
+++ b/src/components/shared/templates/MarkdownArticle.vue
@@ -1,110 +1,62 @@
 <script setup>
-  import { ref, onMounted, watchEffect } from 'vue'
-  import { marked } from 'marked'
+import { ref, onMounted, watch } from 'vue'
+import { marked } from 'marked'
+import BaseArticle from './BaseArticle.vue'
 
+try {
+  const renderer = new marked.Renderer()
+  renderer.table = (header, body) =>
+    `<div class="table-responsive"><table class="table table-striped table-hover">\n<thead class="table-dark">${header}</thead>\n<tbody>${body}</tbody>\n</table></div>`
+  marked.setOptions({ renderer })
+} catch {
+  /* istanbul ignore next */
+}
+
+/**
+ * Article template that loads Markdown content.
+ *
+ * @prop {string} src path to the markdown file
+ * @prop {string} title heading text displayed above the content
+ * @prop {string} meta small subtitle or metadata string
+ * @prop {boolean} expanded whether the article is open by default (default: true)
+ */
+const props = defineProps({
+  src: { type: String, required: true },
+  title: String,
+  meta: String,
+  expanded: {
+    type: Boolean,
+    default: true,
+  },
+})
+
+const content = ref('')
+
+async function loadMarkdown() {
   try {
-    const renderer = new marked.Renderer()
-    renderer.table = (header, body) =>
-      `<div class="table-responsive"><table class="table table-striped table-hover">\n<thead class="table-dark">${header}</thead>\n<tbody>${body}</tbody>\n</table></div>`
-    marked.setOptions({ renderer })
+    const response = await fetch(props.src)
+    const text = await response.text()
+    content.value = marked.parse(text)
   } catch {
-    /* istanbul ignore next */
+    content.value = '<p>Failed to load content.</p>'
   }
+}
 
-  /**
-   * Article template that loads Markdown content.
-   *
-   * @prop {string} src path to the markdown file
-   * @prop {string} title heading text displayed above the content
-   * @prop {string} meta small subtitle or metadata string
-   * @prop {boolean} expanded whether the article is open by default (default: true)
-   */
-  const props = defineProps({
-    src: { type: String, required: true },
-    title: String,
-    meta: String,
-    expanded: {
-      type: Boolean,
-      default: true,
-    },
-  })
-
-  const isExpanded = ref(props.expanded)
-  const content = ref('')
-
-  // Keep isExpanded in sync with prop changes
-  watchEffect(() => {
-    isExpanded.value = props.expanded
-  })
-
-  async function loadMarkdown() {
-    try {
-      const response = await fetch(props.src)
-      const text = await response.text()
-      content.value = marked.parse(text)
-    } catch {
-      content.value = '<p>Failed to load content.</p>'
-    }
-  }
-
-  function toggleExpanded() {
-    isExpanded.value = !isExpanded.value
-  }
-
-  onMounted(loadMarkdown)
+onMounted(loadMarkdown)
+watch(
+  () => props.src,
+  () => loadMarkdown()
+)
 </script>
 
 <template>
-  <div class="row p-4 mb-4 rounded-3 border shadow-lg">
-    <article class="blog-post">
-      <div class="d-flex justify-content-between align-items-start cursor-pointer" @click="toggleExpanded">
-        <div>
-          <h3 class="display-6 link-body-emphasis mb-0">{{ title }}</h3>
-          <p class="blog-post-meta">
-            <em>{{ meta }}</em>
-          </p>
-        </div>
-        <button class="btn btn-sm p-1 text-muted article-toggle" :aria-label="isExpanded ? 'Collapse section' : 'Expand section'">
-          <i class="bi" :class="isExpanded ? 'bi-chevron-up' : 'bi-chevron-down'"></i>
-        </button>
-      </div>
-
-      <div class="article-content" :class="{ collapsed: !isExpanded }" v-html="content" />
-    </article>
-  </div>
+  <BaseArticle v-bind="props">
+    <div v-html="content" />
+  </BaseArticle>
 </template>
 
 <style scoped>
-  .cursor-pointer {
-    cursor: pointer;
-  }
-
-  .article-toggle {
-    border: none !important;
-    background: none !important;
-    transition: transform 0.2s ease;
-  }
-
-  .article-toggle:hover {
-    transform: scale(1.1);
-  }
-
-  .article-content {
-    overflow: hidden;
-    transition:
-      max-height 0.3s ease,
-      opacity 0.3s ease;
-    opacity: 1;
-  }
-
-  /* Bootstrap handles table responsiveness, but we can add some custom styling if needed */
-  .article-content .table-responsive {
-    margin: 1rem 0;
-  }
-
-  .article-content.collapsed {
-    max-height: 0;
-    opacity: 0;
-  }
+.article-content .table-responsive {
+  margin: 1rem 0;
+}
 </style>
-


### PR DESCRIPTION
## Summary
- add BaseArticle wrapper with shared header, toggle logic and styles
- refactor Article and MarkdownArticle to render inside BaseArticle
- document BaseArticle entry point

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c9150d8a48323835fbb960b1b473e