### PR TITLE
docs: clarify setup and add testing guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,34 @@ A Vue 3 single-page application that serves as a personal passion project focuse
 
 ## Quick Start
 
-```sh
-# Install dependencies
-npm install
+1. **Install Node.js** – this project is tested with Node 20+. Earlier versions
+   may not support the tooling used here.
+2. **Install dependencies**:
 
-# Start development server (port 8080)
-npm start
-```
+   ```sh
+   npm install
+   ```
+3. **Add environment variables** – create a `.env` file in the project root
+   with your Supabase credentials:
+
+   ```
+   VITE_SUPABASE_URL=<your-project-url>
+   VITE_SUPABASE_ANON_KEY=<your-public-anon-key>
+   ```
+
+   A sample file is not provided and the process for obtaining these values is
+   currently undocumented. Ask a maintainer for the correct values or use your
+   own Supabase project.
+4. **Start the development server** (port 8080):
+
+   ```sh
+   npm start
+   ```
+5. **Run the tests** to confirm your setup:
+
+   ```sh
+   npm test
+   ```
 
 ## Available Scripts
 
@@ -83,6 +104,7 @@ Complete project documentation is organized in the [`docs/`](docs/README.md) dir
 - [Code Map](docs/codemap.md)
 - [Configuration](docs/configuration.md)
 - [SCSS](docs/scss.md)
+- [Testing](docs/testing.md)
 - Components
   - [Overview](docs/components/README.md)
   - [Navigation](docs/components/layout/navigation.md)
@@ -97,15 +119,28 @@ Some sections require password authentication:
 - `/experiments` - Personal experiments and projects
 - `/habit` - Personal habit tracking
 
-Authentication is handled via Supabase integration.
+Authentication is handled via Supabase integration. The setup process for the
+required Supabase tables and initial passwords is not currently documented, so
+new contributors should check with a maintainer for the correct configuration.
 
 ## Testing
 
-The project uses a mix of Vitest and Node's built-in test runner:
+The project mixes two testing tools:
 
-- Unit tests: Located in `/tests` directory
-- Coverage reporting: Enabled via `--experimental-test-coverage`
-- Test files: Follow `.test.js` and `.spec.js` naming conventions
+- **Vitest** drives component and page tests in a simulated browser
+  environment.
+- **Node's built-in test runner** handles composables and router logic, with
+  coverage enabled via `--experimental-test-coverage`.
+
+Run all tests and linting with:
+
+```sh
+npm test
+```
+
+See [docs/testing.md](docs/testing.md) for a breakdown of the test folders and
+commands. The reason for using two different runners is not documented; ask a
+maintainer if you are unsure about the current strategy.
 
 ## License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ Centralized documentation for the Small Steps project.
 - [Code Map](codemap.md)
 - [Configuration](configuration.md)
 - [SCSS](scss.md)
+- [Testing](testing.md)
 - [Components](components/README.md)
   - Layout
     - [Navigation](components/layout/navigation.md)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,51 @@
+# Testing
+
+[\u2190 Back to documentation index](README.md)
+
+This project uses two different test runners. Components and pages run under
+[Vitest](https://vitest.dev) so they can mount Vue code in a browser-like
+environment. Composables and router logic rely on Node's built-in test runner,
+which provides lightweight coverage reporting via the
+`--experimental-test-coverage` flag.
+
+## Test Structure
+
+- `tests/components` and `tests/pages` use Vitest with `@vue/test-utils`.
+- `tests/composables` and `tests/router` use the Node test runner.
+
+The reason for splitting the test suites across two tools is not currently
+explained in the codebase. If you are unsure which runner to use for new tests,
+check with the project maintainers.
+
+## Running Tests
+
+From the project root, run all tests and the linter:
+
+```sh
+npm test
+```
+
+You can run specific groups of tests:
+
+```sh
+npm run test:components   # Vue component tests
+npm run test:composables  # Composable logic via Node test runner
+npm run test:router       # Router tests via Node test runner
+npm run test:pages        # Page-level tests with Vitest
+```
+
+## Linting
+
+`npm test` automatically runs ESLint after the test suites. To run the linter
+by itself:
+
+```sh
+npm run lint
+```
+
+## Notes
+
+The documentation does not currently describe how Supabase or other external
+services are mocked during testing. If additional setup is required (e.g.
+seeding databases or providing environment variables), please update this guide
+accordingly.


### PR DESCRIPTION
## Summary
- expand README quick start with Node requirements, `.env` config and testing reminder
- note missing Supabase setup details for password-protected sections
- add dedicated testing guide and link it from documentation index

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c910bb7748323bb2b29fe54a1ccd2