### PR TITLE
Simplify navigation prefetch cleanup

### DIFF
--- a/src/components/layout/navigation/AppNavigation.vue
+++ b/src/components/layout/navigation/AppNavigation.vue
@@ -52,7 +52,6 @@
   })
 
   onBeforeUnmount(() => {
-    clearTimeout(prefetchTimer)
     cancelPrefetch()
   })
 

--- a/tests/components/layout/navigation/AppNavigation.auth.test.js
+++ b/tests/components/layout/navigation/AppNavigation.auth.test.js
@@ -94,8 +94,8 @@ test('clears prefetch timer and invokes cancelPrefetch on unmount', () => {
 
   wrapper.unmount()
 
-  // clearTimeout should run once directly and once via cancelPrefetch
-  expect(clearTimeoutSpy).toHaveBeenCalledTimes(2)
+  // clearTimeout should run once via cancelPrefetch
+  expect(clearTimeoutSpy).toHaveBeenCalledTimes(1)
 
   // ensure the scheduled prefetch never runs
   vi.runAllTimers()


### PR DESCRIPTION
## Summary
- remove direct `clearTimeout` use from navigation unmount cleanup
- rely on `cancelPrefetch` for prefetch timer management
- update tests for streamlined cleanup behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689cb83a9c30832389941258ace078d1