### PR TITLE
refactor: expose env constants

### DIFF
--- a/src/configuration/authentication/useAuthentication.js
+++ b/src/configuration/authentication/useAuthentication.js
@@ -1,6 +1,6 @@
 import { ref, computed, watchEffect } from 'vue'
 import routes from '../routes.js'
-import { env } from '../env.js'
+import { VITE_APP_PASSWORD } from '../env.js'
 
 const isAuthenticated = ref(false)
 
@@ -53,7 +53,7 @@ watchEffect(() => {
  */
 export function useAuthentication() {
   // Password from environment variable via getter
-  const CORRECT_PASSWORD = env.getViteAppPassword()
+  const CORRECT_PASSWORD = VITE_APP_PASSWORD
 
   const authenticate = (password) => {
     if (!CORRECT_PASSWORD) {

--- a/src/configuration/env.js
+++ b/src/configuration/env.js
@@ -1,7 +1,16 @@
-export const env = {
-  getViteAppPassword: () => import.meta.env?.VITE_APP_PASSWORD ?? globalThis.process?.env?.VITE_APP_PASSWORD,
-  getViteSupabaseUrl: () => import.meta.env?.VITE_SUPABASE_URL ?? globalThis.process?.env?.VITE_SUPABASE_URL,
-  getViteSupabaseAnonKey: () => import.meta.env?.VITE_SUPABASE_ANON_KEY ?? globalThis.process?.env?.VITE_SUPABASE_ANON_KEY,
-}
+const importMetaEnv = import.meta?.env ?? {}
+const processEnv = globalThis.process?.env ?? {}
 
-export const { getViteAppPassword, getViteSupabaseUrl, getViteSupabaseAnonKey } = env
+const {
+  VITE_APP_PASSWORD,
+  VITE_SUPABASE_URL,
+  VITE_SUPABASE_ANON_KEY,
+} = { ...processEnv, ...importMetaEnv }
+
+export const env = Object.freeze({
+  VITE_APP_PASSWORD,
+  VITE_SUPABASE_URL,
+  VITE_SUPABASE_ANON_KEY,
+})
+
+export { VITE_APP_PASSWORD, VITE_SUPABASE_URL, VITE_SUPABASE_ANON_KEY }

--- a/src/configuration/supabase.js
+++ b/src/configuration/supabase.js
@@ -1,5 +1,5 @@
 import { createClient } from '@supabase/supabase-js'
-import { env } from './env.js'
+import { VITE_SUPABASE_URL, VITE_SUPABASE_ANON_KEY } from './env.js'
 
 /**
  * Initialise and export a configured Supabase client.
@@ -12,8 +12,8 @@ import { env } from './env.js'
  * @returns {import('@supabase/supabase-js').SupabaseClient} ready-to-use client
  */
 // Environment variables with fallbacks for development and testing
-const supabaseUrl = env.getViteSupabaseUrl()
-const supabaseKey = env.getViteSupabaseAnonKey()
+const supabaseUrl = VITE_SUPABASE_URL
+const supabaseKey = VITE_SUPABASE_ANON_KEY
 
 // Validate required environment variables
 if (!supabaseUrl) {

--- a/tests/configuration/env.test.js
+++ b/tests/configuration/env.test.js
@@ -23,19 +23,19 @@ test('reads variables from import.meta.env', { concurrency: false }, async () =>
     VITE_SUPABASE_URL: 'url',
     VITE_SUPABASE_ANON_KEY: 'anon',
   }
-  const { getViteAppPassword, getViteSupabaseUrl, getViteSupabaseAnonKey } = await loadEnvModule(importEnv, {})
+  const { VITE_APP_PASSWORD, VITE_SUPABASE_URL, VITE_SUPABASE_ANON_KEY } = await loadEnvModule(importEnv, {})
 
-  assert.equal(getViteAppPassword(), 'password')
-  assert.equal(getViteSupabaseUrl(), 'url')
-  assert.equal(getViteSupabaseAnonKey(), 'anon')
+  assert.equal(VITE_APP_PASSWORD, 'password')
+  assert.equal(VITE_SUPABASE_URL, 'url')
+  assert.equal(VITE_SUPABASE_ANON_KEY, 'anon')
 
   delete importEnv.VITE_APP_PASSWORD
   delete importEnv.VITE_SUPABASE_URL
   delete importEnv.VITE_SUPABASE_ANON_KEY
 
-  assert.equal(getViteAppPassword(), undefined)
-  assert.equal(getViteSupabaseUrl(), undefined)
-  assert.equal(getViteSupabaseAnonKey(), undefined)
+  assert.equal(VITE_APP_PASSWORD, 'password')
+  assert.equal(VITE_SUPABASE_URL, 'url')
+  assert.equal(VITE_SUPABASE_ANON_KEY, 'anon')
 })
 
 test('falls back to process.env when import.meta.env missing', { concurrency: false }, async () => {
@@ -44,17 +44,24 @@ test('falls back to process.env when import.meta.env missing', { concurrency: fa
     VITE_SUPABASE_URL: 'supabase',
     VITE_SUPABASE_ANON_KEY: 'key',
   }
-  const { getViteAppPassword, getViteSupabaseUrl, getViteSupabaseAnonKey } = await loadEnvModule({}, processEnv)
+  const { VITE_APP_PASSWORD, VITE_SUPABASE_URL, VITE_SUPABASE_ANON_KEY } = await loadEnvModule({}, processEnv)
 
-  assert.equal(getViteAppPassword(), 'pass')
-  assert.equal(getViteSupabaseUrl(), 'supabase')
-  assert.equal(getViteSupabaseAnonKey(), 'key')
+  assert.equal(VITE_APP_PASSWORD, 'pass')
+  assert.equal(VITE_SUPABASE_URL, 'supabase')
+  assert.equal(VITE_SUPABASE_ANON_KEY, 'key')
 
   delete processEnv.VITE_APP_PASSWORD
   delete processEnv.VITE_SUPABASE_URL
   delete processEnv.VITE_SUPABASE_ANON_KEY
 
-  assert.equal(getViteAppPassword(), undefined)
-  assert.equal(getViteSupabaseUrl(), undefined)
-  assert.equal(getViteSupabaseAnonKey(), undefined)
+  assert.equal(VITE_APP_PASSWORD, 'pass')
+  assert.equal(VITE_SUPABASE_URL, 'supabase')
+  assert.equal(VITE_SUPABASE_ANON_KEY, 'key')
+})
+
+test('env object is frozen', { concurrency: false }, async () => {
+  const { env } = await loadEnvModule({ VITE_APP_PASSWORD: 'password' }, {})
+  assert.throws(() => {
+    env.VITE_APP_PASSWORD = 'hack'
+  })
 })

--- a/tests/configuration/supabase.test.js
+++ b/tests/configuration/supabase.test.js
@@ -5,18 +5,21 @@ import vm from 'node:vm'
 
 async function loadSupabaseModule({ url, key }) {
   const code = await readFile(new URL('../../src/configuration/supabase.js', import.meta.url), 'utf8')
-  const transformed = code.replace("import { createClient } from '@supabase/supabase-js'\n", '').replace("import { env } from './env.js'\n", '').replace('export const supabase', 'const supabase')
+  const transformed = code
+    .replace("import { createClient } from '@supabase/supabase-js'\n", '')
+    .replace("import { VITE_SUPABASE_URL, VITE_SUPABASE_ANON_KEY } from './env.js'\n", '')
+    .replace('export const supabase', 'const supabase')
   const calls = []
   const createClientMock = (...args) => {
     calls.push(args)
     return {}
   }
-  const envMock = {
-    getViteSupabaseUrl: () => url,
-    getViteSupabaseAnonKey: () => key,
-  }
   try {
-    vm.runInNewContext(transformed, { createClient: createClientMock, env: envMock })
+    vm.runInNewContext(transformed, {
+      createClient: createClientMock,
+      VITE_SUPABASE_URL: url,
+      VITE_SUPABASE_ANON_KEY: key,
+    })
     return { calls }
   } catch (err) {
     err.calls = calls

--- a/tests/pages/pageTestUtils.js
+++ b/tests/pages/pageTestUtils.js
@@ -5,14 +5,14 @@ import { vi } from 'vitest'
 import { h } from 'vue'
 
 vi.mock('../../src/configuration/env.js', () => ({
-  env: {
-    getViteAppPassword: () => 'secret',
-    getViteSupabaseUrl: () => 'https://example.supabase.co',
-    getViteSupabaseAnonKey: () => 'anon',
-  },
-  getViteAppPassword: () => 'secret',
-  getViteSupabaseUrl: () => 'https://example.supabase.co',
-  getViteSupabaseAnonKey: () => 'anon',
+  env: Object.freeze({
+    VITE_APP_PASSWORD: 'secret',
+    VITE_SUPABASE_URL: 'https://example.supabase.co',
+    VITE_SUPABASE_ANON_KEY: 'anon',
+  }),
+  VITE_APP_PASSWORD: 'secret',
+  VITE_SUPABASE_URL: 'https://example.supabase.co',
+  VITE_SUPABASE_ANON_KEY: 'anon',
 }))
 
 /**

--- a/tests/testUtils.js
+++ b/tests/testUtils.js
@@ -1,5 +1,3 @@
-import { env } from '../src/configuration/env.js'
-
 export const PASSWORD = 'secret'
 
 export function setupTestEnvironment(t, { password = PASSWORD } = {}) {
@@ -16,10 +14,19 @@ export function setupTestEnvironment(t, { password = PASSWORD } = {}) {
     },
   }
 
-  const passwordMock = t.mock.method(env, 'getViteAppPassword', () => password)
+  const originalPassword = process.env.VITE_APP_PASSWORD
+  if (password === null || password === undefined) {
+    delete process.env.VITE_APP_PASSWORD
+  } else {
+    process.env.VITE_APP_PASSWORD = password
+  }
 
   t.after(() => {
     global.sessionStorage = originalSessionStorage
-    passwordMock.mock.restore()
+    if (originalPassword === undefined) {
+      delete process.env.VITE_APP_PASSWORD
+    } else {
+      process.env.VITE_APP_PASSWORD = originalPassword
+    }
   })
 }


### PR DESCRIPTION
## Summary
- resolve required Vite env vars once and export them as frozen constants
- consume new env constants in Supabase and authentication modules
- refresh tests to use direct constants and adjust helpers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689cc19b468c83238744c0e95128234b