### PR TITLE
feat: refactor navigation and prefetch logic

### DIFF
--- a/src/composables/useNavigation.js
+++ b/src/composables/useNavigation.js
@@ -1,0 +1,59 @@
+import { computed } from 'vue'
+import { useRouter } from 'vue-router'
+
+/**
+ * Build navigation structures from router route records.
+ *
+ * Routes that define `meta.navLabel` are included. Optional `meta.navGroup`
+ * groups routes into dropdown sections.
+ *
+ * Returned helpers:
+ * - `navigationItems` for top-level links
+ * - `dropdownSections` for grouped items keyed by group name
+ */
+export function useNavigation() {
+  const router = useRouter()
+  const routes = router
+    .getRoutes()
+    .filter((r) => r.meta && r.meta.navLabel)
+
+  const navigationItems = computed(() =>
+    routes
+      .filter((r) => !r.meta.navGroup)
+      .map((r) => ({
+        path: r.path,
+        label: r.meta.navLabel,
+        requiresAuth: !!r.meta.requiresAuth,
+        icon: r.meta.icon,
+        badge: r.meta.badge,
+      }))
+  )
+
+  const dropdownSections = computed(() => {
+    const sections = {}
+    routes
+      .filter((r) => r.meta.navGroup)
+      .forEach((route) => {
+        const group = route.meta.navGroup
+        if (!sections[group]) {
+          sections[group] = {
+            label: group.charAt(0).toUpperCase() + group.slice(1),
+            items: [],
+          }
+        }
+        sections[group].items.push({
+          path: route.path,
+          label: route.meta.navLabel,
+          requiresAuth: !!route.meta.requiresAuth,
+          icon: route.meta.icon,
+          badge: route.meta.badge,
+        })
+      })
+    return sections
+  })
+
+  return {
+    navigationItems,
+    dropdownSections,
+  }
+}

--- a/src/composables/usePrefetch.js
+++ b/src/composables/usePrefetch.js
@@ -1,0 +1,37 @@
+import { onBeforeUnmount } from 'vue'
+import { useRouter } from 'vue-router'
+
+/**
+ * Provide helpers for prefetching route components on hover.
+ *
+ * Returns `prefetch(path)` and `cancelPrefetch()` functions. Prefetched paths
+ * are cached to avoid repeated network requests.
+ */
+export function usePrefetch() {
+  const router = useRouter()
+  const prefetched = new Set()
+  let prefetchTimer
+
+  const prefetch = (path) => {
+    if (prefetched.has(path)) return
+    clearTimeout(prefetchTimer)
+    prefetchTimer = setTimeout(() => {
+      const route = router.resolve(path)
+      route.matched.forEach((record) => {
+        const component = record.components?.default
+        if (typeof component === 'function') {
+          component()
+        }
+      })
+      prefetched.add(path)
+    }, 150)
+  }
+
+  const cancelPrefetch = () => {
+    clearTimeout(prefetchTimer)
+  }
+
+  onBeforeUnmount(cancelPrefetch)
+
+  return { prefetch, cancelPrefetch }
+}

--- a/src/configuration/authentication/useAuthentication.js
+++ b/src/configuration/authentication/useAuthentication.js
@@ -30,7 +30,7 @@ watchEffect(() => {
 })
 
 /**
- * Manage client-side authentication state and navigation visibility.
+ * Manage client-side authentication state and basic route access checks.
  *
  * Returned helpers include:
  * - `isAuthenticated` reactive boolean flag
@@ -38,7 +38,6 @@ watchEffect(() => {
  *   matches the configured value
  * - `logout()` to clear the session
  * - route helpers: `isRouteRestricted`, `isRoutePublic`, `canAccessRoute`
- * - navigation builders: `navigationItems`, `dropdownSections`
  *
  * @returns {{
  *  isAuthenticated: import('vue').ComputedRef<boolean>,
@@ -47,8 +46,6 @@ watchEffect(() => {
  *  isRouteRestricted: (path: string) => boolean,
  *  isRoutePublic: (path: string) => boolean,
  *  canAccessRoute: (path: string) => boolean,
- *  navigationItems: import('vue').ComputedRef<Array>,
- *  dropdownSections: import('vue').ComputedRef<Record<string, any>>
  * }} reactive auth helpers and route guards
  */
 export function useAuthentication() {
@@ -85,47 +82,6 @@ export function useAuthentication() {
     return isRoutePublic(path) || isAuthenticated.value
   }
 
-  // Build primary navigation menu, hiding restricted routes for unauthenticated users
-  const navigationItems = computed(() => {
-    return routes
-      .filter((route) => !route.meta?.group)
-      .map((route) => ({
-        path: route.path,
-        label: route.meta?.label || route.path,
-        public: !route.meta?.requiresAuth,
-      }))
-      .filter((navigationItem) => navigationItem.public || isAuthenticated.value)
-  })
-
-  const dropdownSections = computed(() => {
-    const sectionsByGroup = {}
-    routes.forEach((route) => {
-      const meta = route.meta || {}
-      if (!meta.group) return
-
-      if (!sectionsByGroup[meta.group]) {
-        sectionsByGroup[meta.group] = {
-          label: meta.group.charAt(0).toUpperCase() + meta.group.slice(1),
-          public: !meta.requiresAuth,
-          items: [],
-        }
-      }
-
-      sectionsByGroup[meta.group].public = sectionsByGroup[meta.group].public && !meta.requiresAuth
-      sectionsByGroup[meta.group].items.push({ path: route.path, label: meta.label })
-    })
-
-    const visibleSections = {}
-    Object.keys(sectionsByGroup).forEach((sectionName) => {
-      const sectionDetails = sectionsByGroup[sectionName]
-      if (sectionDetails.public || isAuthenticated.value) {
-        visibleSections[sectionName] = sectionDetails
-      }
-    })
-
-    return visibleSections
-  })
-
   return {
     isAuthenticated: computed(() => isAuthenticated.value),
     authenticate,
@@ -133,7 +89,5 @@ export function useAuthentication() {
     isRouteRestricted,
     isRoutePublic,
     canAccessRoute,
-    navigationItems,
-    dropdownSections,
   }
 }

--- a/src/configuration/routes.js
+++ b/src/configuration/routes.js
@@ -39,23 +39,99 @@ const Pisicuta = () => import('@/pages/pisicuta/Pisicuta.vue')
 const Laptops = () => import('@/pages/pisicuta/laptops/Laptops.vue')
 
 export default [
-  { path: '/', component: Home, meta: { label: 'Home', group: null, requiresAuth: false } },
-  { path: '/ikigai', component: Ikigai, meta: { label: 'Ikigai', group: null, requiresAuth: true } },
-  { path: '/ippo', component: Ippo, meta: { label: 'Ippo', group: null, requiresAuth: true } },
-  { path: '/experiments', component: Experiments, meta: { label: 'Experiments', group: null, requiresAuth: true } },
-  { path: '/random', component: Random, meta: { label: 'Random', group: null, requiresAuth: true } },
-  { path: '/literature', component: Literature, meta: { label: 'Overview', group: 'literature', requiresAuth: false } },
-  { path: '/books', component: Books, meta: { label: 'Books', group: 'literature', requiresAuth: false } },
-  { path: '/poems', component: Poems, meta: { label: 'Poems', group: 'literature', requiresAuth: false } },
-  { path: '/entertainment', component: Entertainment, meta: { label: 'Overview', group: 'entertainment', requiresAuth: false } },
-  { path: '/anime', component: Anime, meta: { label: 'Anime', group: 'entertainment', requiresAuth: false } },
-  { path: '/movies', component: Movies, meta: { label: 'Movies', group: 'entertainment', requiresAuth: false } },
-  { path: '/nutrition', component: Nutrition, meta: { label: 'Overview', group: 'nutrition', requiresAuth: false } },
-  { path: '/nutrition/ingredients', component: Ingredients, meta: { label: 'Ingredients', group: 'nutrition', requiresAuth: false } },
-  { path: '/adventure', component: Adventure, meta: { label: 'Overview', group: 'adventure', requiresAuth: false } },
-  { path: '/adventure/destinations', component: Destinations, meta: { label: 'Destinations', group: 'adventure', requiresAuth: false } },
-  { path: '/habit', component: Habit, meta: { label: 'Overview', group: 'habit', requiresAuth: true } },
-  { path: '/habit/tracker', component: Tracker, meta: { label: 'Tracker', group: 'habit', requiresAuth: true } },
-  { path: '/pisicuta', component: Pisicuta, meta: { label: 'Overview', group: 'pisicuta', requiresAuth: true } },
-  { path: '/pisicuta/laptops', component: Laptops, meta: { label: 'Laptops', group: 'pisicuta', requiresAuth: true } },
+  {
+    path: '/',
+    component: Home,
+    meta: { navLabel: 'Home', navGroup: null, requiresAuth: false, icon: 'bi-house' },
+  },
+  {
+    path: '/ikigai',
+    component: Ikigai,
+    meta: { navLabel: 'Ikigai', navGroup: null, requiresAuth: true, icon: 'bi-lightbulb' },
+  },
+  {
+    path: '/ippo',
+    component: Ippo,
+    meta: { navLabel: 'Ippo', navGroup: null, requiresAuth: true, icon: 'bi-flag' },
+  },
+  {
+    path: '/experiments',
+    component: Experiments,
+    meta: { navLabel: 'Experiments', navGroup: null, requiresAuth: true, icon: 'bi-gear' },
+  },
+  {
+    path: '/random',
+    component: Random,
+    meta: { navLabel: 'Random', navGroup: null, requiresAuth: true, icon: 'bi-shuffle' },
+  },
+  {
+    path: '/literature',
+    component: Literature,
+    meta: { navLabel: 'Overview', navGroup: 'literature', requiresAuth: false, icon: 'bi-journal' },
+  },
+  {
+    path: '/books',
+    component: Books,
+    meta: { navLabel: 'Books', navGroup: 'literature', requiresAuth: false, icon: 'bi-book', badge: '4' },
+  },
+  {
+    path: '/poems',
+    component: Poems,
+    meta: { navLabel: 'Poems', navGroup: 'literature', requiresAuth: false, icon: 'bi-pencil' },
+  },
+  {
+    path: '/entertainment',
+    component: Entertainment,
+    meta: { navLabel: 'Overview', navGroup: 'entertainment', requiresAuth: false, icon: 'bi-controller' },
+  },
+  {
+    path: '/anime',
+    component: Anime,
+    meta: { navLabel: 'Anime', navGroup: 'entertainment', requiresAuth: false, icon: 'bi-emoji-smile' },
+  },
+  {
+    path: '/movies',
+    component: Movies,
+    meta: { navLabel: 'Movies', navGroup: 'entertainment', requiresAuth: false, icon: 'bi-film' },
+  },
+  {
+    path: '/nutrition',
+    component: Nutrition,
+    meta: { navLabel: 'Overview', navGroup: 'nutrition', requiresAuth: false, icon: 'bi-egg' },
+  },
+  {
+    path: '/nutrition/ingredients',
+    component: Ingredients,
+    meta: { navLabel: 'Ingredients', navGroup: 'nutrition', requiresAuth: false, icon: 'bi-list-ul' },
+  },
+  {
+    path: '/adventure',
+    component: Adventure,
+    meta: { navLabel: 'Overview', navGroup: 'adventure', requiresAuth: false, icon: 'bi-map' },
+  },
+  {
+    path: '/adventure/destinations',
+    component: Destinations,
+    meta: { navLabel: 'Destinations', navGroup: 'adventure', requiresAuth: false, icon: 'bi-geo-alt' },
+  },
+  {
+    path: '/habit',
+    component: Habit,
+    meta: { navLabel: 'Overview', navGroup: 'habit', requiresAuth: true, icon: 'bi-calendar-check' },
+  },
+  {
+    path: '/habit/tracker',
+    component: Tracker,
+    meta: { navLabel: 'Tracker', navGroup: 'habit', requiresAuth: true, icon: 'bi-graph-up' },
+  },
+  {
+    path: '/pisicuta',
+    component: Pisicuta,
+    meta: { navLabel: 'Overview', navGroup: 'pisicuta', requiresAuth: true, icon: 'bi-laptop' },
+  },
+  {
+    path: '/pisicuta/laptops',
+    component: Laptops,
+    meta: { navLabel: 'Laptops', navGroup: 'pisicuta', requiresAuth: true, icon: 'bi-laptop' },
+  },
 ]

--- a/tests/components/layout/navigation/AppNavigation.auth.test.js
+++ b/tests/components/layout/navigation/AppNavigation.auth.test.js
@@ -20,21 +20,23 @@ vi.mock('vue-router', () => ({
 
 // Mock authentication composable with reactive auth state
 const isAuthenticated = ref(false)
-const navigationItems = computed(() =>
-  isAuthenticated.value
-    ? [
-        { path: '/public', label: 'Public' },
-        { path: '/private', label: 'Private' },
-      ]
-    : [{ path: '/public', label: 'Public' }]
-)
 const logoutMock = vi.fn()
 vi.mock('@/configuration/authentication/useAuthentication.js', () => ({
   useAuthentication: () => ({
     isAuthenticated: computed(() => isAuthenticated.value),
+    logout: logoutMock,
+  }),
+}))
+
+// Mock navigation composable to supply structural data
+const navigationItems = computed(() => [
+  { path: '/public', label: 'Public', requiresAuth: false },
+  { path: '/private', label: 'Private', requiresAuth: true },
+])
+vi.mock('@/composables/useNavigation.js', () => ({
+  useNavigation: () => ({
     navigationItems,
     dropdownSections: computed(() => ({})),
-    logout: logoutMock,
   }),
 }))
 


### PR DESCRIPTION
## Summary
- enrich route meta with navigation labels, groups, and icons
- introduce `useNavigation` and `usePrefetch` composables for menu building and link prefetching
- update `AppNavigation` to use new composables and render icons/badges

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689cc02af6b0832383e5364cf9249956