### PR TITLE
Handle Supabase resource initialization errors

### DIFF
--- a/src/composables/useActivities.js
+++ b/src/composables/useActivities.js
@@ -236,13 +236,21 @@ export function useActivities() {
     handleActivitiesChange
   )
 
+  async function initialize() {
+    const result = await resourceInitialize()
+    if (result.error) {
+      error.value = result.error.message || result.error
+    }
+    return result
+  }
+
   function cleanup() {
     resourceCleanup()
     sessionOverrides.clear()
   }
 
   // Auto-initialize when composable is used
-  resourceInitialize()
+  initialize()
 
   return {
     // Data
@@ -258,7 +266,7 @@ export function useActivities() {
     setActivityStatus,
     isActivityDone,
     getKeysForHabit,
-    initialize: resourceInitialize,
+    initialize,
     cleanup,
   }
 }

--- a/src/composables/useHabits.js
+++ b/src/composables/useHabits.js
@@ -190,7 +190,19 @@ export function useHabits() {
     }
   }
 
-  const { initialize, cleanup } = useSupabaseResource('habits', loadHabits, handleHabitsChange)
+  const { initialize: resourceInitialize, cleanup } = useSupabaseResource(
+    'habits',
+    loadHabits,
+    handleHabitsChange
+  )
+
+  async function initialize() {
+    const result = await resourceInitialize()
+    if (result.error) {
+      error.value = result.error.message || result.error
+    }
+    return result
+  }
 
   // Auto-initialize when composable is used
   initialize()

--- a/src/composables/useSupabaseResource.js
+++ b/src/composables/useSupabaseResource.js
@@ -7,29 +7,42 @@ import { supabase } from '@/configuration/supabase.js'
  * @param {string} tableName - database table to subscribe to
  * @param {Function} loadFn - async function loading initial data
  * @param {Function} changeHandler - callback for realtime changes
- * @returns {{initialize: Function, cleanup: Function}}
+ * @returns {{
+ *   initialize: () => Promise<{ status?: string, error?: Error }>,
+ *   cleanup: Function
+ * }}
  */
 export function useSupabaseResource(tableName, loadFn, changeHandler) {
   let subscription = null
   let isInitialized = false
 
   async function initialize() {
-    if (isInitialized) return
-
-    if (loadFn) {
-      await loadFn()
+    if (isInitialized) {
+      cleanup()
     }
 
-    subscription = supabase
-      .channel(`${tableName}_changes`)
-      .on('postgres_changes', { event: '*', schema: 'public', table: tableName }, (payload) => {
-        if (changeHandler) {
-          changeHandler(payload)
-        }
-      })
-      .subscribe()
+    try {
+      if (loadFn) {
+        await loadFn()
+      }
 
-    isInitialized = true
+      subscription = supabase
+        .channel(`${tableName}_changes`)
+        .on('postgres_changes', { event: '*', schema: 'public', table: tableName }, (payload) => {
+          if (changeHandler) {
+            changeHandler(payload)
+          }
+        })
+        .subscribe()
+
+      isInitialized = true
+      return { status: 'initialized' }
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error(`Error initializing ${tableName} subscription:`, error)
+      cleanup()
+      return { error }
+    }
   }
 
   function cleanup() {


### PR DESCRIPTION
## Summary
- add error-handled initialize logic to Supabase resource helper
- reinitialize Supabase channels safely and expose status to callers
- propagate initialization errors in activities and habits composables

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689cc151f8f48323a2fe400541dfa64c