### PR TITLE
Refactor authentication helpers and route access utilities

### DIFF
--- a/src/configuration/authentication/routeAccess.js
+++ b/src/configuration/authentication/routeAccess.js
@@ -1,0 +1,45 @@
+// Pure utilities for evaluating route access based on route metadata.
+
+/**
+ * Build a Map of route metadata keyed by path for efficient lookup.
+ *
+ * @param {Array<import('vue-router').RouteRecordRaw>} routes
+ * @returns {Map<string, any>} Map from path to meta object
+ */
+export function buildRouteMetaMap(routes) {
+  return new Map(routes.map((route) => [route.path, route.meta || {}]))
+}
+
+/**
+ * Determine whether the given path requires authentication.
+ *
+ * @param {Map<string, any>} metaMap
+ * @param {string} path
+ * @returns {boolean}
+ */
+export function isRouteRestricted(metaMap, path) {
+  return Boolean(metaMap.get(path)?.requiresAuth)
+}
+
+/**
+ * Determine whether the given path is public (does not require authentication).
+ *
+ * @param {Map<string, any>} metaMap
+ * @param {string} path
+ * @returns {boolean}
+ */
+export function isRoutePublic(metaMap, path) {
+  return !isRouteRestricted(metaMap, path)
+}
+
+/**
+ * Determine whether the user can access the given path.
+ *
+ * @param {Map<string, any>} metaMap
+ * @param {string} path
+ * @param {boolean} authenticated
+ * @returns {boolean}
+ */
+export function canAccessRoute(metaMap, path, authenticated) {
+  return isRoutePublic(metaMap, path) || authenticated
+}

--- a/tests/components/layout/navigation/AppNavigation.auth.test.js
+++ b/tests/components/layout/navigation/AppNavigation.auth.test.js
@@ -1,6 +1,6 @@
 import { mount } from '@vue/test-utils'
 import { test, expect, vi } from 'vitest'
-import { ref, computed, nextTick } from 'vue'
+import { ref, computed, nextTick, readonly } from 'vue'
 import AppNavigation from '@/components/layout/navigation/AppNavigation.vue'
 
 // Mock router to observe prefetch calls
@@ -23,7 +23,7 @@ const isAuthenticated = ref(false)
 const logoutMock = vi.fn()
 vi.mock('@/configuration/authentication/useAuthentication.js', () => ({
   useAuthentication: () => ({
-    isAuthenticated: computed(() => isAuthenticated.value),
+    isAuthenticated: readonly(isAuthenticated),
     logout: logoutMock,
   }),
 }))

--- a/tests/composables/useAuthentication.test.js
+++ b/tests/composables/useAuthentication.test.js
@@ -6,9 +6,9 @@ import { setupTestEnvironment, PASSWORD } from '../testUtils.js'
 
 async function setup(t) {
   setupTestEnvironment(t)
-  const { useAuthentication } = await import('../../src/configuration/authentication/useAuthentication.js')
+  const { useAuthentication, resetAuth } = await import('../../src/configuration/authentication/useAuthentication.js')
+  resetAuth()
   const auth = useAuthentication()
-  auth.logout()
   return auth
 }
 

--- a/tests/pages/pageTestUtils.js
+++ b/tests/pages/pageTestUtils.js
@@ -112,8 +112,9 @@ export async function resolveRoute(pathName, authenticated = false) {
   const { createAppRouter } = await import('../../src/configuration/router.js')
   const router = createAppRouter(createMemoryHistory(), routes)
 
+  const { useAuthentication, resetAuth } = await import('../../src/configuration/authentication/useAuthentication.js')
+  resetAuth()
   if (authenticated) {
-    const { useAuthentication } = await import('../../src/configuration/authentication/useAuthentication.js')
     const auth = useAuthentication()
     auth.authenticate('secret')
   }

--- a/tests/router/router.test.js
+++ b/tests/router/router.test.js
@@ -8,15 +8,15 @@ import { setupTestEnvironment, PASSWORD } from '../testUtils.js'
 async function setup(t, authenticated = false) {
   setupTestEnvironment(t)
 
-  const { useAuthentication } = await import('../../src/configuration/authentication/useAuthentication.js')
+  const { useAuthentication, resetAuth } = await import('../../src/configuration/authentication/useAuthentication.js')
   const { createAppRouter } = await import('../../src/configuration/router.js')
 
   // Stub components to avoid loading .vue files
   const routes = rawRoutes.map((route) => ({ ...route, component: {} }))
 
   const router = createAppRouter(createMemoryHistory(), routes)
+  resetAuth()
   const auth = useAuthentication()
-  auth.logout()
   if (authenticated) auth.authenticate(PASSWORD)
   await router.push('/')
   return router


### PR DESCRIPTION
## Summary
- expose authentication state as a readonly ref
- derive route access with pure map-based utilities
- add `resetAuth` helper for tests and refresh related specs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cc722a7a88323a46d6bcbc57a0723