### PR TITLE
feat: add fitness page with habit tracker

### DIFF
--- a/src/configuration/routes.js
+++ b/src/configuration/routes.js
@@ -26,6 +26,11 @@ const Movies = () => import('@/pages/entertainment/Movies.vue')
 const Nutrition = () => import('@/pages/nutrition/Nutrition.vue')
 const Ingredients = () => import('@/pages/nutrition/ingredients/Ingredients.vue')
 
+// Fitness Components
+const Fitness = () => import('@/pages/fitness/Fitness.vue')
+const StrengthWorkout = () => import('@/pages/fitness/workouts/Strength.vue')
+const CardioWorkout = () => import('@/pages/fitness/workouts/Cardio.vue')
+
 // Adventure Components
 const Adventure = () => import('@/pages/adventure/Adventure.vue')
 const Destinations = () => import('@/pages/adventure/destinations/Destinations.vue')
@@ -103,6 +108,21 @@ export default [
     path: '/nutrition/ingredients',
     component: Ingredients,
     meta: { navLabel: 'Ingredients', navGroup: 'nutrition', requiresAuth: false, icon: 'bi-list-ul' },
+  },
+  {
+    path: '/fitness',
+    component: Fitness,
+    meta: { navLabel: 'Fitness', navGroup: null, requiresAuth: false, icon: 'bi-heart-pulse' },
+  },
+  {
+    path: '/fitness/workouts/strength',
+    component: StrengthWorkout,
+    meta: { requiresAuth: false },
+  },
+  {
+    path: '/fitness/workouts/cardio',
+    component: CardioWorkout,
+    meta: { requiresAuth: false },
   },
   {
     path: '/adventure',

--- a/src/pages/fitness/Fitness.vue
+++ b/src/pages/fitness/Fitness.vue
@@ -1,0 +1,76 @@
+<script setup>
+  import { computed } from 'vue'
+  import ArticleTemplate from '@/components/shared/templates/Article.vue'
+  import ActionsTemplate from '@/components/shared/templates/actions/Actions.vue'
+  import { useHabits } from '@/composables/useHabits.js'
+  import { useActivities } from '@/composables/useActivities.js'
+
+  defineOptions({
+    name: 'FitnessTemplate',
+  })
+
+  const { habitsData, loading: habitsLoading, error: habitsError } = useHabits()
+  const {
+    loading: activitiesLoading,
+    error: activitiesError,
+    isActivityDone,
+    setActivityStatus,
+  } = useActivities()
+
+  const TIMEZONE = 'Europe/Bucharest'
+  function getTodayKey() {
+    const now = new Date(new Date().toLocaleString('en-US', { timeZone: TIMEZONE }))
+    const year = now.getFullYear()
+    const month = String(now.getMonth() + 1).padStart(2, '0')
+    const day = String(now.getDate()).padStart(2, '0')
+    return `${year}-${month}-${day}`
+  }
+  const todayKey = getTodayKey()
+
+  const fitnessHabits = computed(() =>
+    habitsData.value.habits.filter((habit) => habit.category === 'fitness')
+  )
+
+  function toggleHabit(habitId) {
+    const done = !isActivityDone(habitId, todayKey)
+    setActivityStatus(habitId, todayKey, done)
+  }
+</script>
+
+<template>
+  <ArticleTemplate title="Fitness Actions" meta="Aug 6, 2025 by G. D. Ungureanu">
+    <ActionsTemplate list-id="987cd0c1-a7e1-4e6a-aa4e-52a0da41d652" />
+  </ArticleTemplate>
+
+  <ArticleTemplate title="Workout Templates" meta="Aug 6, 2025 by G. D. Ungureanu">
+    <ul>
+      <li>
+        <router-link to="/fitness/workouts/strength"><strong>Strength Training</strong></router-link>
+      </li>
+      <li>
+        <router-link to="/fitness/workouts/cardio"><strong>Cardio Blast</strong></router-link>
+      </li>
+    </ul>
+  </ArticleTemplate>
+
+  <ArticleTemplate title="Exercise Habit Tracker" meta="Aug 6, 2025 by G. D. Ungureanu">
+    <div v-if="habitsLoading || activitiesLoading">Loading habits...</div>
+    <div v-else-if="habitsError || activitiesError">Failed to load habits.</div>
+    <div v-else>
+      <ul v-if="fitnessHabits.length">
+        <li v-for="habit in fitnessHabits" :key="habit.id">
+          <label>
+            <input
+              type="checkbox"
+              :checked="isActivityDone(habit.id, todayKey)"
+              @change="toggleHabit(habit.id)"
+            />
+            {{ habit.name }}
+          </label>
+        </li>
+      </ul>
+      <p v-else>No fitness habits found.</p>
+    </div>
+  </ArticleTemplate>
+</template>
+

--- a/src/pages/fitness/workouts/Cardio.vue
+++ b/src/pages/fitness/workouts/Cardio.vue
@@ -1,0 +1,14 @@
+<script setup>
+  import ArticleTemplate from '@/components/shared/templates/Article.vue'
+
+  defineOptions({
+    name: 'CardioWorkoutTemplate',
+  })
+</script>
+
+<template>
+  <ArticleTemplate title="Cardio Workout Template" meta="Aug 6, 2025 by G. D. Ungureanu">
+    <p>Use this template for your cardio routines.</p>
+  </ArticleTemplate>
+</template>
+

--- a/src/pages/fitness/workouts/Strength.vue
+++ b/src/pages/fitness/workouts/Strength.vue
@@ -1,0 +1,14 @@
+<script setup>
+  import ArticleTemplate from '@/components/shared/templates/Article.vue'
+
+  defineOptions({
+    name: 'StrengthWorkoutTemplate',
+  })
+</script>
+
+<template>
+  <ArticleTemplate title="Strength Training Template" meta="Aug 6, 2025 by G. D. Ungureanu">
+    <p>Plan your strength sessions with this template.</p>
+  </ArticleTemplate>
+</template>
+


### PR DESCRIPTION
## Summary
- add Fitness page with workout template links
- integrate basic habit tracking for exercise goals
- register fitness routes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689cc6c530e8832388e29e663aa98236