### PR TITLE
refactor: consolidate auth imports in router tests

### DIFF
--- a/tests/router/router.test.js
+++ b/tests/router/router.test.js
@@ -11,10 +11,9 @@ import { setupTestEnvironment, PASSWORD } from '../testUtils.js'
 async function setup(t, authenticated = false) {
   setupTestEnvironment(t)
 
-  const { useAuthentication } = await import(
+  const { useAuthentication, resetAuth } = await import(
     '../../src/configuration/authentication/useAuthentication.js'
   )
-  const { useAuthentication, resetAuth } = await import('../../src/configuration/authentication/useAuthentication.js')
   const { createAppRouter } = await import('../../src/configuration/router.js')
 
   // Stub components to avoid loading .vue files


### PR DESCRIPTION
## Summary
- consolidate useAuthentication and resetAuth into a single dynamic import in router tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689cd155ef54832398084a42bd8d6caf