### PR TITLE
refactor: render laptop articles with v-for

### DIFF
--- a/src/pages/pisicuta/laptops/Laptops.vue
+++ b/src/pages/pisicuta/laptops/Laptops.vue
@@ -3,8 +3,18 @@
 
   const markdownResearchUrl1 = new URL('./Research1.md', import.meta.url).href
   const markdownResearchUrl2 = new URL('./Research2.md', import.meta.url).href
-
-
+  const articles = [
+    {
+      src: markdownResearchUrl2,
+      title: 'Laptops Research 2021-2025',
+      meta: 'August 12, 2025 by G. D. Ungureanu',
+    },
+    {
+      src: markdownResearchUrl1,
+      title: 'Laptops Research 2022-2023',
+      meta: 'August 11, 2025 by G. D. Ungureanu',
+    },
+  ]
   defineOptions({
     name: 'LaptopsTemplate',
   })
@@ -12,16 +22,9 @@
 
 <template>
   <MarkdownArticleTemplate
-    :src="markdownResearchUrl2"
-    title="Laptops Research 2021-2025"
-    meta="August 12, 2025 by G. D. Ungureanu"
-    :expanded="false"
-  />
-
-  <MarkdownArticleTemplate
-    :src="markdownResearchUrl1"
-    title="Laptops Research 2022-2023"
-    meta="August 11, 2025 by G. D. Ungureanu"
+    v-for="item in articles"
+    v-bind="item"
+    :key="item.src"
     :expanded="false"
   />
 </template>


### PR DESCRIPTION
## Summary
- replace duplicated laptop articles with a single MarkdownArticleTemplate loop
- define reusable article metadata array
- explicitly set expanded state to false for each laptop article

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cd6c37d0c8323ac029ce32e5ffb0d