### PR TITLE
refactor: use constant for investments list id

### DIFF
--- a/src/pages/finance/Investments.vue
+++ b/src/pages/finance/Investments.vue
@@ -2,6 +2,8 @@
   import ArticleTemplate from '@/components/shared/templates/Article.vue'
   import ActionsTemplate from '@/components/shared/templates/actions/Actions.vue'
 
+  const LIST_ID = '33333333-3333-3333-3333-333333333333'
+
   defineOptions({
     name: 'InvestmentsTemplate',
   })
@@ -9,7 +11,7 @@
 
 <template>
   <ArticleTemplate title="Investment Actions" meta="July 31, 2025 by G. D. Ungureanu">
-    <ActionsTemplate list-id="33333333-3333-3333-3333-333333333333" />
+    <ActionsTemplate :list-id="LIST_ID" />
   </ArticleTemplate>
 </template>
 


### PR DESCRIPTION
## Summary
- use `LIST_ID` constant for Investments page actions

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689cebc124e883239594a4aea9d718a1