### PR TITLE
refactor: use constant for finance list id

### DIFF
--- a/src/pages/finance/Finance.vue
+++ b/src/pages/finance/Finance.vue
@@ -5,11 +5,13 @@
   defineOptions({
     name: 'FinanceTemplate',
   })
+
+  const LIST_ID = '11111111-1111-1111-1111-111111111111'
 </script>
 
 <template>
   <ArticleTemplate title="Finance Actions" meta="July 31, 2025 by G. D. Ungureanu">
-    <ActionsTemplate list-id="11111111-1111-1111-1111-111111111111" />
+    <ActionsTemplate :list-id="LIST_ID" />
   </ArticleTemplate>
 </template>
 


### PR DESCRIPTION
## Summary
- define `LIST_ID` constant in Finance page script
- bind `:list-id` prop to `LIST_ID`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cebbfe15c8323bd0b83f9baf224e8