### PR TITLE
test: assert rel="noopener noreferrer" on footer link

### DIFF
--- a/src/components/layout/footer/AppFooter.vue
+++ b/src/components/layout/footer/AppFooter.vue
@@ -4,7 +4,13 @@
   <div class="text-center">
     <p class="text-muted">
       &copy; Memento Mori |
-      <a href="https://github.com/GDUngureanu" class="text-decoration-none">G. D. Ungureanu</a>
+      <a
+        href="https://github.com/GDUngureanu"
+        class="text-decoration-none"
+        rel="noopener noreferrer"
+      >
+        G. D. Ungureanu
+      </a>
     </p>
   </div>
 </template>

--- a/tests/components/layout/footer/AppFooter.test.js
+++ b/tests/components/layout/footer/AppFooter.test.js
@@ -7,5 +7,6 @@ test('AppFooter always renders copyright line and link', () => {
   expect(wrapper.text()).toContain('© Memento Mori')
   const link = wrapper.get('a')
   expect(link.attributes('href')).toBe('https://github.com/GDUngureanu')
+  expect(link.attributes('rel')).toBe('noopener noreferrer')
   expect(link.text()).toBe('G. D. Ungureanu')
 })


### PR DESCRIPTION
## Summary
- add `rel="noopener noreferrer"` to footer link
- check `rel` attribute in AppFooter test
- format footer markup

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ceba7db448323ad144b2fefd2954d