### PR TITLE
refactor: use constant list id for literature actions

### DIFF
--- a/src/pages/literature/Literature.vue
+++ b/src/pages/literature/Literature.vue
@@ -5,10 +5,12 @@
   defineOptions({
     name: 'LiteratureTemplate',
   })
+
+  const LIST_ID = '7a171dc3-50bd-4732-b912-08f25fcba7a6'
 </script>
 
 <template>
   <ArticleTemplate title="Literature Actions" meta="July 31, 2025 by G. D. Ungureanu">
-    <ActionsTemplate list-id="7a171dc3-50bd-4732-b912-08f25fcba7a6" />
+    <ActionsTemplate :list-id="LIST_ID" />
   </ArticleTemplate>
 </template>


### PR DESCRIPTION
## Summary
- define `LIST_ID` constant in Literature page
- bind `ActionsTemplate` to `LIST_ID`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cf211ffe483239450a017e8f7d32c