### PR TITLE
Broaden navigation to medium screens

### DIFF
--- a/src/core/layout/navigation/AppNavigation.vue
+++ b/src/core/layout/navigation/AppNavigation.vue
@@ -46,7 +46,7 @@
   })
 
   const closeMenu = () => {
-    if (window.innerWidth < 992 && bootstrapOffcanvas) {
+    if (window.innerWidth < 768 && bootstrapOffcanvas) {
       bootstrapOffcanvas.hide()
     }
   }
@@ -60,7 +60,7 @@
   <nav class="navbar fixed-top d-block" data-navbar-on-scroll="data-navbar-on-scroll">
     <div class="container">
       <button
-        class="navbar-toggler d-lg-none"
+        class="navbar-toggler d-md-none"
         type="button"
         data-bs-toggle="offcanvas"
         data-bs-target="#navOffcanvas"
@@ -70,7 +70,7 @@
         <span class="navbar-toggler-icon"></span>
       </button>
 
-      <div class="d-none d-lg-flex w-100 border-top" id="navbarSupportedContent">
+      <div class="d-none d-md-flex w-100 border-top" id="navbarSupportedContent">
         <ul class="navbar-nav me-auto">
           <li v-for="item in navigationItems" :key="item.path" class="nav-item px-2">
             <RouterLink
@@ -143,7 +143,7 @@
   </nav>
 
   <div
-    class="offcanvas offcanvas-start d-lg-none"
+    class="offcanvas offcanvas-start d-md-none"
     tabindex="-1"
     id="navOffcanvas"
     aria-labelledby="navOffcanvasLabel"

--- a/tests/core/layout/navigation/AppNavigation.test.js
+++ b/tests/core/layout/navigation/AppNavigation.test.js
@@ -46,7 +46,7 @@ afterEach(() => {
   vi.useRealTimers()
 })
 
-test('offcanvas opens and hides on small screens and ignores large screens', async () => {
+test('offcanvas opens and hides on small screens and ignores medium and large screens', async () => {
   Object.defineProperty(global.window, 'innerWidth', { configurable: true, value: 500 })
 
   const wrapper = mount(AppNavigation, {
@@ -62,7 +62,7 @@ test('offcanvas opens and hides on small screens and ignores large screens', asy
   expect(hideSpy).toHaveBeenCalled()
 
   hideSpy.mockClear()
-  Object.defineProperty(global.window, 'innerWidth', { configurable: true, value: 1200 })
+  Object.defineProperty(global.window, 'innerWidth', { configurable: true, value: 800 })
   await wrapper.find('a').trigger('click')
   expect(hideSpy).not.toHaveBeenCalled()
 })


### PR DESCRIPTION
## Summary
- Make navigation horizontal for medium and large screens while retaining offcanvas on small screens
- Adjust closeMenu logic to match new breakpoint
- Update navigation test to cover medium-width behavior

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689decd77eb48323b5ab68a132cdf587