### PR TITLE
test: add axe accessibility smoke test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,7 @@
 
 /node_modules/
 /dist/
+/playwright-report/
+/test-results/
 
 CLAUDE.md

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test:pages": "vitest run --dir tests/domains",
     "test:unit": "npm run test:components",
     "test": "npm run test:unit && npm run test:pages && npm run lint",
+    "test:e2e": "playwright test",
     "predeploy": "npm run build",
     "deploy": "gh-pages -d dist"
   },
@@ -35,6 +36,8 @@
     "vue-router": "^4.5.1"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.9.2",
+    "@playwright/test": "^1.49.0",
     "@vitejs/plugin-vue": "^5.2.4",
     "@vue/test-utils": "^2.4.5",
     "eslint": "^9.27.0",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,14 @@
+import { defineConfig } from '@playwright/test'
+
+export default defineConfig({
+  testDir: 'tests/e2e',
+  use: {
+    baseURL: 'http://localhost:8080',
+    headless: true,
+  },
+  webServer: {
+    command: 'npm run start',
+    url: 'http://localhost:8080',
+    reuseExistingServer: !process.env.CI,
+  },
+})

--- a/tests/e2e/a11y.spec.js
+++ b/tests/e2e/a11y.spec.js
@@ -1,0 +1,9 @@
+import { test, expect } from '@playwright/test'
+import AxeBuilder from '@axe-core/playwright'
+
+test('home page has no detectable accessibility violations', async ({ page }) => {
+  await page.goto('/')
+  const results = await new AxeBuilder({ page }).analyze()
+  const serious = results.violations.filter(v => ['serious', 'critical'].includes(v.impact))
+  expect(serious).toEqual([])
+})


### PR DESCRIPTION
## Summary
- add Playwright config and axe-core accessibility smoke test
- expose `test:e2e` npm script and required dev dependencies
- ignore Playwright artifacts

## Testing
- `npm test`
- `npm run test:e2e` *(fails: playwright not found)*
- `npm install` *(fails: 403 Forbidden for @axe-core/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_689ded369af08323adf4d582d918eac5