### PR TITLE
feat(router): use HTML5 history for clean URLs

### DIFF
--- a/src/core/navigation/router.js
+++ b/src/core/navigation/router.js
@@ -1,4 +1,4 @@
-import { createRouter, createWebHashHistory } from 'vue-router'
+import { createRouter, createWebHistory } from 'vue-router'
 import routes from './routes.js'
 import { useAuthentication } from '../auth/useAuthentication.js'
 import { authenticationEvents, AUTH_REQUIRED_EVENT } from '../auth/authenticationEvents.js'
@@ -6,14 +6,18 @@ import { authenticationEvents, AUTH_REQUIRED_EVENT } from '../auth/authenticatio
 /**
  * Create a Vue Router instance with a simple authentication guard.
  *
- * Any route whose `meta.requiresAuth` flag is `true` will redirect to `/` when
- * the user is not authenticated according to `useAuthentication`.
+ * Uses HTML5 history for clean URLs. Any route whose `meta.requiresAuth` flag
+ * is `true` will redirect to `/` when the user is not authenticated according
+ * to `useAuthentication`.
  *
  * @param {import('vue-router').RouterHistory} [history] custom history implementation
  * @param {Array<import('vue-router').RouteRecordRaw>} [routesConfig] route definitions
  * @returns {import('vue-router').Router} configured router
  */
-export function createAppRouter(history = createWebHashHistory(), routesConfig = routes) {
+export function createAppRouter(
+  history = createWebHistory(import.meta.env.BASE_URL),
+  routesConfig = routes,
+) {
   const router = createRouter({
     history,
     routes: routesConfig,


### PR DESCRIPTION
## Summary
- use `createWebHistory` as the default router history for cleaner, SEO-friendly URLs

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install --no-fund --no-audit --progress=false` *(fails: 403 Forbidden for @axe-core/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_689df0ed0f1c832399a8cede40a225cc