### PR TITLE
feat: add pinia stores for auth and navigation

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "bootstrap-icons": "^1.13.1",
     "leaflet": "^1.9.4",
     "marked": "^12.0.2",
+    "pinia": "^2.1.7",
     "vue": "^3.5.14",
     "vue-router": "^4.5.1"
   },

--- a/src/core/auth/useAuthentication.js
+++ b/src/core/auth/useAuthentication.js
@@ -1,58 +1,37 @@
-import { ref, watchEffect, readonly } from 'vue'
+import { ref, watchEffect } from 'vue'
+import { defineStore } from 'pinia'
 import routes from '../navigation/routes.js'
 import env from '../config/env.js'
 import { buildRouteMetaMap, isRouteRestricted as isRouteRestrictedUtil, isRoutePublic as isRoutePublicUtil, canAccessRoute as canAccessRouteUtil } from './routeAccess.js'
 
-const isAuthenticated = ref(false)
-
 // Build a lookup of route metadata for quick access checks
 const routeMeta = buildRouteMetaMap(routes)
 
-// Check sessionStorage on initialization
-if (typeof sessionStorage !== 'undefined') {
-  const storedAuthentication = sessionStorage.getItem('memento-mori-authentication')
-  if (storedAuthentication === 'true') {
-    isAuthenticated.value = true
+export const useAuthentication = defineStore('auth', () => {
+  const isAuthenticated = ref(false)
+
+  if (typeof sessionStorage !== 'undefined') {
+    const storedAuthentication = sessionStorage.getItem('memento-mori-authentication')
+    if (storedAuthentication === 'true') {
+      isAuthenticated.value = true
+    }
   }
-}
 
-// Automatically sync authentication state with sessionStorage
-watchEffect(() => {
-  if (typeof sessionStorage === 'undefined') return
+  // Automatically sync authentication state with sessionStorage
+  watchEffect(() => {
+    if (typeof sessionStorage === 'undefined') return
+    if (isAuthenticated.value) {
+      sessionStorage.setItem('memento-mori-authentication', 'true')
+    } else {
+      sessionStorage.removeItem('memento-mori-authentication')
+    }
+  })
 
-  if (isAuthenticated.value) {
-    sessionStorage.setItem('memento-mori-authentication', 'true')
-  } else {
-    sessionStorage.removeItem('memento-mori-authentication')
-  }
-})
-
-/**
- * Manage client-side authentication state and basic route access checks.
- *
- * Returned helpers include:
- * - `isAuthenticated` reactive boolean flag
- * - `authenticate(password)` to set the flag when the supplied password
- *   matches the configured value
- * - `logout()` to clear the session
- * - route helpers: `isRouteRestricted`, `isRoutePublic`, `canAccessRoute`
- *
- * @returns {{
- *  isAuthenticated: import('vue').Ref<boolean>,
- *  authenticate: (password: string) => boolean,
- *  logout: () => void,
- *  isRouteRestricted: (path: string) => boolean,
- *  isRoutePublic: (path: string) => boolean,
- *  canAccessRoute: (path: string) => boolean,
- * }} reactive auth helpers and route guards
- */
-export function useAuthentication() {
   const authenticate = (password) => {
     if (password === env.VITE_APP_PASSWORD) {
       isAuthenticated.value = true
       return true
     }
-
     return false
   }
 
@@ -73,17 +52,18 @@ export function useAuthentication() {
   }
 
   return {
-    isAuthenticated: readonly(isAuthenticated),
+    isAuthenticated,
     authenticate,
     logout,
     isRouteRestricted,
     isRoutePublic,
     canAccessRoute,
   }
-}
+})
 
 export function resetAuth() {
-  isAuthenticated.value = false
+  const auth = useAuthentication()
+  auth.logout()
   if (typeof sessionStorage !== 'undefined') {
     sessionStorage.removeItem('memento-mori-authentication')
   }

--- a/src/core/layout/navigation/AppNavigation.vue
+++ b/src/core/layout/navigation/AppNavigation.vue
@@ -11,16 +11,16 @@
    * Structural data comes from `useNavigation` while authentication state is
    * handled by `useAuthentication`.
    */
-  const { isAuthenticated, logout } = useAuthentication()
-  const { navigationItems: allNavigationItems, dropdownSections: allDropdownSections } = useNavigation()
+  const auth = useAuthentication()
+  const navigation = useNavigation()
   const { prefetch, cancelPrefetch } = usePrefetch()
 
-  const navigationItems = computed(() => allNavigationItems.value.filter((item) => !item.requiresAuth || isAuthenticated.value))
+  const navigationItems = computed(() => navigation.navigationItems.filter((item) => !item.requiresAuth || auth.isAuthenticated))
 
   const dropdownSections = computed(() => {
     const sections = {}
-    Object.entries(allDropdownSections.value).forEach(([key, section]) => {
-      const items = section.items.filter((item) => !item.requiresAuth || isAuthenticated.value)
+    Object.entries(navigation.dropdownSections).forEach(([key, section]) => {
+      const items = section.items.filter((item) => !item.requiresAuth || auth.isAuthenticated)
       if (items.length) {
         sections[key] = { ...section, items }
       }
@@ -90,14 +90,14 @@
 
         <!-- Auth controls -->
         <ul class="navbar-nav">
-          <li v-if="!isAuthenticated" class="nav-item px-2">
+          <li v-if="!auth.isAuthenticated" class="nav-item px-2">
             <button @click="showAuthenticationModal" class="btn btn-outline-primary btn-sm">
               <i class="bi bi-unlock"></i>
               Login
             </button>
           </li>
-          <li v-if="isAuthenticated" class="nav-item px-2">
-            <button @click="logout" class="btn btn-outline-secondary btn-sm">
+          <li v-if="auth.isAuthenticated" class="nav-item px-2">
+            <button @click="auth.logout" class="btn btn-outline-secondary btn-sm">
               <i class="bi bi-lock"></i>
               Logout
             </button>
@@ -141,14 +141,14 @@
 
       <!-- Auth controls -->
       <ul class="navbar-nav mt-3">
-        <li v-if="!isAuthenticated" class="nav-item px-2">
+        <li v-if="!auth.isAuthenticated" class="nav-item px-2">
           <button @click="showAuthenticationModal" class="btn btn-outline-primary btn-sm w-100">
             <i class="bi bi-unlock"></i>
             Login
           </button>
         </li>
-        <li v-if="isAuthenticated" class="nav-item px-2">
-          <button @click="logout" class="btn btn-outline-secondary btn-sm w-100">
+        <li v-if="auth.isAuthenticated" class="nav-item px-2">
+          <button @click="auth.logout" class="btn btn-outline-secondary btn-sm w-100">
             <i class="bi bi-lock"></i>
             Logout
           </button>

--- a/src/core/layout/navigation/useNavigation.js
+++ b/src/core/layout/navigation/useNavigation.js
@@ -1,5 +1,6 @@
 import { computed } from 'vue'
 import { useRouter } from 'vue-router'
+import { defineStore } from 'pinia'
 
 /**
  * Build navigation structures from router route records.
@@ -11,7 +12,7 @@ import { useRouter } from 'vue-router'
  * - `navigationItems` for top-level links
  * - `dropdownSections` for grouped items keyed by group name
  */
-export function useNavigation() {
+export const useNavigation = defineStore('navigation', () => {
   const router = useRouter()
   const routes = router.getRoutes().filter((r) => r.meta && r.meta.navLabel)
 
@@ -54,4 +55,4 @@ export function useNavigation() {
     navigationItems,
     dropdownSections,
   }
-}
+})

--- a/src/core/navigation/router.js
+++ b/src/core/navigation/router.js
@@ -23,7 +23,7 @@ export function createAppRouter(history = createWebHistory(import.meta.env.BASE_
   const auth = useAuthentication()
 
   router.beforeEach((to, from, next) => {
-    if (to.meta?.requiresAuth && !auth.isAuthenticated.value) {
+    if (to.meta?.requiresAuth && !auth.isAuthenticated) {
       authenticationEvents.dispatchEvent(new CustomEvent(AUTH_REQUIRED_EVENT, { detail: to.path }))
       return next({ path: '/' })
     }

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,5 @@
 import { createApp } from 'vue'
+import { createPinia } from 'pinia'
 import { Popover } from 'bootstrap'
 import App from '@/App.vue'
 import { createAppRouter } from '@core/navigation/router.js'
@@ -7,12 +8,16 @@ import 'bootstrap-icons/font/bootstrap-icons.css'
 
 // Create the router instance using centralized routes and auth guard
 const router = createAppRouter()
+const pinia = createPinia()
 
 /**
  * Application bootstrap. Mounts the root component with the configured
  * router and wires up Bootstrap popovers for opt-in elements.
  */
-createApp(App).use(router).mount('#app')
+const app = createApp(App)
+app.use(pinia)
+app.use(router)
+app.mount('#app')
 
 document.querySelectorAll('[data-bs-toggle="popover"]').forEach((popover) => {
   new Popover(popover)

--- a/tests/core/layout/navigation/AppNavigation.auth.test.js
+++ b/tests/core/layout/navigation/AppNavigation.auth.test.js
@@ -1,6 +1,6 @@
 import { mount } from '@vue/test-utils'
 import { test, expect, vi, afterEach } from 'vitest'
-import { ref, computed, nextTick, readonly } from 'vue'
+import { ref, computed, nextTick } from 'vue'
 import AppNavigation from '@/core/layout/navigation/AppNavigation.vue'
 
 // Mock router to observe prefetch calls
@@ -23,7 +23,9 @@ const isAuthenticated = ref(false)
 const logoutMock = vi.fn()
 vi.mock('@/core/auth/useAuthentication.js', () => ({
   useAuthentication: () => ({
-    isAuthenticated: readonly(isAuthenticated),
+    get isAuthenticated() {
+      return isAuthenticated.value
+    },
     logout: logoutMock,
   }),
 }))
@@ -33,7 +35,7 @@ const navigationItems = computed(() => [
   { path: '/public', label: 'Public', requiresAuth: false },
   { path: '/private', label: 'Private', requiresAuth: true },
 ])
-vi.mock('@/composables/useNavigation.js', () => ({
+vi.mock('@/core/layout/navigation/useNavigation.js', () => ({
   useNavigation: () => ({
     navigationItems,
     dropdownSections: computed(() => ({})),

--- a/tests/core/layout/navigation/AppNavigation.test.js
+++ b/tests/core/layout/navigation/AppNavigation.test.js
@@ -24,12 +24,14 @@ vi.mock('bootstrap', () => ({
 
 vi.mock('@/core/auth/useAuthentication.js', () => ({
   useAuthentication: () => ({
-    isAuthenticated: computed(() => false),
+    get isAuthenticated() {
+      return false
+    },
     logout: vi.fn(),
   }),
 }))
 
-vi.mock('@/composables/useNavigation.js', () => ({
+vi.mock('@/core/layout/navigation/useNavigation.js', () => ({
   useNavigation: () => ({
     navigationItems: computed(() => [{ path: '/test', label: 'Test', requiresAuth: false }]),
     dropdownSections: computed(() => ({})),

--- a/tests/domains/pageTestUtils.js
+++ b/tests/domains/pageTestUtils.js
@@ -1,5 +1,6 @@
 import { mount } from '@vue/test-utils'
 import { createRouter, createMemoryHistory } from 'vue-router'
+import { createPinia, setActivePinia } from 'pinia'
 import rawRoutes from '../../src/core/navigation/routes.js'
 import { h } from 'vue'
 
@@ -36,11 +37,12 @@ export async function renderComponent(file, options = {}) {
     history: createMemoryHistory(),
     routes,
   })
+  const pinia = createPinia()
 
   const wrapper = mount(component, {
     ...options,
     global: {
-      plugins: [router, ...((options.global && options.global.plugins) || [])],
+      plugins: [router, pinia, ...((options.global && options.global.plugins) || [])],
       stubs: {
         RouterLink: true,
         RouterView: true,
@@ -101,6 +103,7 @@ export async function resolveRoute(pathName, authenticated = false) {
   const router = createAppRouter(createMemoryHistory(), routes)
 
   const { useAuthentication, resetAuth } = await import('../../src/core/auth/useAuthentication.js')
+  setActivePinia(createPinia())
   resetAuth()
   if (authenticated) {
     const auth = useAuthentication()


### PR DESCRIPTION
## Summary
- install pinia and register it during app bootstrap
- refactor authentication logic into a Pinia store
- expose navigation links via a Pinia store and use them in the nav component and router

## Testing
- `npm run format`
- `npm run lint:check`
- `npm run test` *(fails: Cannot find module 'pinia')*

## Checklist
- [ ] Clear title + job story + screenshots/GIF
- [ ] Small PR (≤ 300 LOC) and isolated scope
- [ ] Types strict, no `any`; unreachable code removed
- [ ] Errors handled & user messages shown
- [ ] a11y basics (labels, roles, focus)
- [ ] Unit & component tests added/updated; e2e if flow changed
- [ ] Docs/readme or story updated; env vars listed
- [ ] Self-reviewed: formatter, linter, dead code deleted

------
https://chatgpt.com/codex/tasks/task_e_689dfa30903083239a1b24d28f382321